### PR TITLE
Final adjustments and promotion to prod for JET and OC lessons

### DIFF
--- a/lessons/lesson-25/syringe.yaml
+++ b/lessons/lesson-25/syringe.yaml
@@ -17,10 +17,18 @@ devices:
   - 830
   - 1883
   - 32767
+- name: vqfx2
+  image: antidotelabs/vqfx-full:18.1R1.9
+  ports:
+  - 830
+  - 1883
+  - 32767
 
 connections:
 - a: vqfx
   b: linux
+- a: vqfx
+  b: vqfx1
 
 stages:
   - id: 1

--- a/lessons/lesson-26/stage3/guide.md
+++ b/lessons/lesson-26/stage3/guide.md
@@ -53,6 +53,7 @@ Then we install the custom YANG module by `request system yang add` command:
 
 ```
 request system yang add package vpn-services module vpn-services.yang translation-script vpn-services.py
+yes
 ```
 <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 3)">Run this snippet</button>
 

--- a/lessons/lesson-26/stage4/guide.md
+++ b/lessons/lesson-26/stage4/guide.md
@@ -58,7 +58,7 @@ dev.open()
 Then we load the configuration, print the diff, and commit:
 
 ```
-dev.cu.load(path='vpn-services.conf', format='text')
+dev.cu.load(path='/antidote/lessons/lesson-26/vpn-services.conf', format='text')
 dev.cu.pdiff()
 dev.cu.commit(timeout=600)
 ```

--- a/lessons/lesson-26/syringe.yaml
+++ b/lessons/lesson-26/syringe.yaml
@@ -2,7 +2,9 @@
 lessonName: Vendor-Neutral Network Configuration with OpenConfig
 lessonId: 26
 category: tools
-tier: ptr
+tier: prod
+prereqs:
+  - 24  # PyEZ
 description: "In this lesson, we'll explore OpenConfig - an industry effort to standardize network configuration and telemetry models"
 slug: openconfig
 


### PR DESCRIPTION
Looks like the majority of the image issues have been sorted. This PR will take care of some last-minute cleanups in the JET and OpenConfig lessons, including the addition of a second image in the JET lesson so that the ping tests in stage 4 will work.

In addition, the two lessons will be promoted to production so they'll show up in the main site in the next release (currently targeted for later this week)

/cc @valjeanchan @jnpr-raylam 