### PR TITLE
Replaced all individual snippet indices with 'this' keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Replaced all individual snippet indices with 'this' keyword [#221](https://github.com/nre-learning/nrelabs-curriculum/pull/221)
 
 ## v0.3.2 - April 19, 2019
 

--- a/lessons/lesson-12/stage1/guide.md
+++ b/lessons/lesson-12/stage1/guide.md
@@ -8,7 +8,7 @@ First, let's take a peek at our network configuration by going to `vqfx1`. We ca
 ```
 show bgp summary
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 This doesn't seem right. You heard from another engineer that this router should be running BGP, so to see that it has no peers configured is concerning.
 
@@ -20,14 +20,14 @@ We can run the below commands on our Ubuntu host to see the JSNAPy configuration
 cd /antidote/lessons/lesson-12/
 cat jsnapy_config.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 We see that the configuration specifies the three routers in our topology. We also see that it references a test file. Let's take a look at that now:
 
 ```
 cat jsnapy_tests.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In this test file, you see that three checks are being performed:
 
@@ -40,5 +40,5 @@ This is a nifty way to state what "normal" is, so we don't have to guess. Let's 
 ```
 jsnapy --snapcheck -f jsnapy_config.yaml -v
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 

--- a/lessons/lesson-12/stage2/guide.md
+++ b/lessons/lesson-12/stage2/guide.md
@@ -7,7 +7,7 @@ In Part 1, we noticed that the router configuration didn't quite match up with w
 cd /antidote/lessons/lesson-12/
 cat jsnapy_tests.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 To review, these tests assert:
 
@@ -20,14 +20,14 @@ In this part (Part 2), our routers have been configured with the correct BGP pee
 ```
 show bgp summary
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 It *looks* good, but as they say, "successful tests or it didn't happen". Let's re-run JSNAPy to make sure our tests are passing with the new configuration:
 
 ```
 jsnapy --snapcheck -f jsnapy_config.yaml -v
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 This time, our network is behaving the way we've declared in the tests, so they pass. It's important to note that our tests not only assert that the right configuration exists, but that the operational state of each router's BGP peer status is correct. This is a nice feature of JSNAPy - it can make assertions over anything in the entire Junos data model.
 

--- a/lessons/lesson-13/stage3/guide.md
+++ b/lessons/lesson-13/stage3/guide.md
@@ -9,14 +9,14 @@ so adding an alias will save us some screen real estate and keystrokes:
 ```
 alias napalm="napalm --user=antidote --password=antidotepassword --vendor=junos"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Using the `-h` flag shows us we have a few subcommands we can use:
 
 ```
 napalm -h
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In this lab we'll focus on the `call` subcommand. This subcommand allows us to execute the "getter" functions, such as `get_interfaces`,
 which we saw used from Python in the previous lab. The cool thing about running this all from the Bash shell is we can take advantage of the multitude of tools for working with text data:
@@ -24,7 +24,7 @@ which we saw used from Python in the previous lab. The cool thing about running 
 ```
 napalm vqfx1 call get_interfaces | jq .em4
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 What just happened? Well, first the command `napalm vqfx1 call get_interfaces` retrieved the full list of network interfaces we saw in the previous example. Then, we piped that big JSON dictionary into the `jq` tool, which allows us to specify a particular key (in this case, `em4`) and only display the value for that key. Thus, we only get `em4`'s interface information. This is the power of using tools like NAPALM at the bash shell - no need to log in to the device and check the interface data one at a time. Just change the hostname or the interface name on this one line.
 
@@ -33,7 +33,7 @@ There are other useful functions we can execute, not just the "getter" functions
 ```
 napalm vqfx1 call ping --method-kwargs="destination='10.0.0.15'"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 There are a few other subcommands, but we'll cover those in either another lesson, or in the case of configuration capabilities, the very next lab.
 For that, we go back into the world of Python...

--- a/lessons/lesson-14/stage1/guide.md
+++ b/lessons/lesson-14/stage1/guide.md
@@ -17,7 +17,7 @@ closely mirror Python's data structures, and the `list` is a prime example. Let'
 cd /antidote/lessons/lesson-14/stage1/
 cat list.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In this lesson, we'll work with this YAML data using the interactive Python shell. Run the below snippet to load up our YAML file in Python:
 
@@ -28,11 +28,11 @@ import sys
 yamlFile = open('list.yaml', 'r')
 yamlList = yaml.load(yamlFile)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 At this point, `yamlList` is a Python list that contains values (in this case, strings) that were in our YAML file. We can start by checking this list's length:
 
 ```
 print("There are %d values in this YAML file" % len(yamlList))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>

--- a/lessons/lesson-14/stage2/guide.md
+++ b/lessons/lesson-14/stage2/guide.md
@@ -11,7 +11,7 @@ A better option for this problem is a Dictionary. They're similar to lists, but 
 cd /antidote/lessons/lesson-14/stage2/
 cat basicdict.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In this lesson, we'll work with this YAML data using the interactive Python shell. Run the below snippet to load up our YAML file in Python:
 
@@ -22,14 +22,14 @@ import sys
 yamlFile = open('basicdict.yaml', 'r')
 yamlDict = yaml.load(yamlFile)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 At this point, `yamlDict` is a Python dictionary that contains the key-value pairs that were in our YAML file. We can start by checking this dictionary's length:
 
 ```
 print("There are %d key-value pairs in this YAML file" % len(yamlDict))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 We can also use a loop to iterate through this dictionary, and print out each key-value pair, and look at their type:
 
@@ -40,14 +40,14 @@ for key, value in yamlDict.items():
     print("The key %s is of type %s and its value %s is of type %s" % (key, type(key), value, type(value)))
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 As mentioned before, dictionaries are useful for looking up a specific value if you know the key, rather than having to know which item in a list that value is found in. In this case, we can simply look up the SNMP community string by referencing the key `snmpcommunity`:
 
 ```
 yamlDict['snmpcommunity']
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 YAML and Python are quite liberal with the types that can be stored in a dictionary. We have a second YAML file that has a list (Python's version of an array), a string, and an integer, all stored as different values in the same dictionary:
 
@@ -57,4 +57,4 @@ yamlDict = yaml.load(yamlFile)
 for key, value in yamlDict.items():
     print("The key %s is of type %s and its value %s is of type %s" % (key, type(key), value, type(value)))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>

--- a/lessons/lesson-15/stage1/guide.md
+++ b/lessons/lesson-15/stage1/guide.md
@@ -25,7 +25,7 @@ flag at various levels to get help output. For instance, if you want an overview
 ```
 st2 -h
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 You'll notice there are several subcommands available to us. Many of these are StackStorm resources that fill specific roles in the event-driven
 automation paradigm, such as `trigger`, `rule`, and `action`. We'll be diving deeper into each of these in the following labs.
@@ -38,7 +38,7 @@ to your favorite command and.....and...... you know what, just run it and see fo
 ```
 st2 --debug run core.local date
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Don't worry about the details of the command we just ran, we'll cover that in detail in the next lab.
 
@@ -51,7 +51,7 @@ If you already know you want to run an action, but you want to know the proper s
 ```
 st2 run -h
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 
 #### StackStorm Packs

--- a/lessons/lesson-15/stage2/guide.md
+++ b/lessons/lesson-15/stage2/guide.md
@@ -22,7 +22,7 @@ For instance, to list the available actions that are currently present on our sy
 ```
 st2 action list
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 You can see that each action is located within a "pack", which we explained in the last lab. For instance, the "core" pack comes pre-installed with StackStorm,
 and contains many common actions for doing simple things like running bash commands, calling a REST API, and more.
@@ -35,7 +35,7 @@ The `local` action in the `core` pack is referred to by it's "full name" as `cor
 ```
 st2 run core.local "echo Hello World!"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Not every action is created equal - like any program or script, each action comes with different parameters - some optional, some required - that are necessary for it
 to get its job done. Fortunately, we can use the handy `-h` flag to gain insight right at the command line into what parameters any action supports:
@@ -43,7 +43,7 @@ to get its job done. Fortunately, we can use the handy `-h` flag to gain insight
 ```
 st2 run core.local -h
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 You can see that the `cmd` parameter is required, and is what we supplied in double quotes - the command to run on the bash shell.
 
@@ -55,7 +55,7 @@ wait for the Action to complete in order to get our terminal back - the `st2` co
 ```
 st2 run -a core.local "sleep 300"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 You may notice that the output contains a reference to another StackStorm command we haven't seen yet:
 
@@ -70,7 +70,7 @@ This is also useful because, as we'll see in the next few labs, we don't always 
 ```
 st2 execution list
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Now, this is a simple example, and there's way more to get into in the `core` pack, such as executing remote commands or scripts, calling REST APIs, and more. However,
 this is a network automation lesson, and there's way too much value in using a tool like StackStorm for event-driven network automation, so let's get
@@ -89,7 +89,7 @@ You might have noticed earlier that this pack is already installed, and the acti
 ```
 st2 action list --pack=napalm
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 
 The `get_facts` action in this pack is a great place to get started. Like we saw in the NAPALM lesson, this action gathers some basic information about a network device, like the serial number and hostname:
@@ -97,14 +97,14 @@ The `get_facts` action in this pack is a great place to get started. Like we saw
 ```
 st2 run napalm.get_facts hostname=vqfx1
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 At this point, you might be asking "Where did we pass in the credentials for vqfx1"? Like many packs, these details are captured in the pack configuration:
 
 ```
 cat /opt/stackstorm/configs/napalm.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 This configuration is specific to the `napalm` pack, and consists of two main parts. A list of devices, which we referred to by name with the `hostname` parameter, and a list
 of credentials, which each device entry references in order to specify which credential set to use.
@@ -114,7 +114,7 @@ Getting facts is kind of cool - but what about something a little more specific?
 ```
 st2 run napalm.get_bgp_neighbors hostname=vqfx1
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Finally, it would be really great if we could actually push a config change with StackStorm.  If you pay attention to the output retrieved in the previous command, you may have noticed that one of our configured BGP peers is inactive. Upon further inspection, we see that the BGP configuration on vqfx1 is using the wrong `peer-as` attribute.
 
@@ -123,14 +123,14 @@ As part of this lesson, we've included a configuration snippet that will replace
 ```
 cat /antidote/lessons/lesson-15/stage2/vqfx1-config-patch.txt
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 The `loadconfig` action can accept this path as a parameter, and will perform a merge between this configuration, and the existing configuration:
 
 ```
 st2 run napalm.loadconfig hostname=vqfx1 config_file="/antidote/lessons/lesson-15/stage2/vqfx1-config-patch.txt"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 11)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 If we go to vqfx1 now, we'll see that both BGP peers are active:
 
@@ -138,7 +138,7 @@ If we go to vqfx1 now, we'll see that both BGP peers are active:
 cli
 show bgp summary
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 12)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 This was a brief look at StackStorm actions, using the `napalm` pack as an example, since it's extremely useful for our purposes here, learning event-driven network automation. However, there are **many** more actions inside many more packs available on the [StackStorm Exchange](https://exchange.stackstorm.org/), and you should definitely check those out as well.
 

--- a/lessons/lesson-15/stage3/guide.md
+++ b/lessons/lesson-15/stage3/guide.md
@@ -31,7 +31,7 @@ The "hello world" example for ActionChains has to be the "echochain" - in partic
 ```
 cat /opt/stackstorm/packs/examples/actions/chains/echochain_param.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Like many things in StackStorm, ActionChain workflows are defined in YAML, and contain two high-level keys:
 
@@ -45,14 +45,14 @@ Just like we previously saw with Actions, we can see which parameters are requir
 ```
 st2 run examples.echochain-param -h
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Again, just like any other Action, we can execute this workflow by passing in the necessary parameters.
 
 ```
 st2 run examples.echochain-param input1="Hello, NRE Labs"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 This output should look mostly familiar, with one big exception; the normal stuff like the execution id, input parameters,
 timestamps, and result values are all there, but there's also a table shown underneath that gives us the ID, status, and
@@ -79,7 +79,7 @@ and ensure StackStorm and Mistral remain in sync with each other regarding workf
 ```
 cat /opt/stackstorm/packs/examples/actions/workflows/mistral-jinja-branching.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Like ActionChains, Mistral workflows are written in YAML, and they also contain a set of tasks (defined as a YAML dictionary this time) under the `tasks` key.
 Each task refers to an `action`, which in the case of a Mistral+Stackstorm deployment like we have here, refers to a StackStorm action.
@@ -137,6 +137,6 @@ As a result, Orquesta workflows are very similar in syntax to Mistral workflows,
 ```
 cat /opt/stackstorm/packs/examples/actions/workflows/orquesta-basic.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 See the [Orquesta](https://docs.stackstorm.com/orquesta.html) for more details on how to write these types of Workflows.

--- a/lessons/lesson-15/stage4/guide.md
+++ b/lessons/lesson-15/stage4/guide.md
@@ -23,7 +23,7 @@ As with everything else, Sensors are distributed within Packs. We can run the fo
 ```
 st2 sensor list --pack=napalm
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Of particular interest for this lab is the `napalm.InterfaceSensor`, which as described, is a sensor that polls network devices for interface up/down events. This sounds awesome, but how is it actually *done*?
 
@@ -32,21 +32,21 @@ The following `get` command gives us a clue:
 ```
 st2 sensor get napalm.InterfaceSensor
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Here, we see a lot more detail about this sensor, including the field `artifact_uri`, which is an absolute path to the actual Python code running this sensor. The contents of this Sensor is a bit beyond the scope of this lesson, but if you're curious, [the documentation](https://docs.stackstorm.com/sensors.html#creating-a-sensor) on creating a Sensor is really good, and it's a really good idea to have that up in another tab while perusing the contents of the Sensor code provided in the command below:
 
 ```
 cat /opt/stackstorm/packs/napalm/sensors/interface_sensor.py
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 How did StackStorm know about this Python code? Every Sensor, like many things in StackStorm, is comprised of two components. A script file - which is what was referenced in the output above - and a metadata YAML file, which describes things like where to find the script file, and other useful metadata:
 
 ```
 cat /opt/stackstorm/packs/napalm/sensors/interface_sensor.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 #### Triggers
 
@@ -61,14 +61,14 @@ Similar to what we did with Sensors, we can list all registered Triggers in the 
 ```
 st2 trigger list --pack=napalm
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 In this output, we see that there are two triggers related to interfaces, `napalm.InterfaceDown` and `napalm.InterfaceUp`. Drilling into the `InterfaceDown` trigger specifically:
 
 ```
 st2 trigger get napalm.InterfaceDown
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 We can see that triggers have properties. This one has two string properties, `device` and `interface`. We'll see those in action shortly, and especially in the next lab.
 
@@ -79,7 +79,7 @@ We can see the list of `trigger-instances` using the command you have probably a
 ```
 st2 trigger-instance list --trigger=napalm.InterfaceDown
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Huh - an empty list? Well, this makes sense, doesn't it? Our Sensor has been busy collecting data, but that data hasn't shown any changes, and no meaningful event has taken place, deserving of a Trigger. Let's cause one. :)
 
@@ -88,7 +88,7 @@ configure
 set interfaces em4 disable
 commit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 Let's see if we've been able to get a Trigger to fire. Note that this interface data is obtained by polling periodically,
 so you may have to run the following command a few times before it shows up:
@@ -96,7 +96,7 @@ so you may have to run the following command a few times before it shows up:
 ```
 st2 trigger-instance list --trigger=napalm.InterfaceDown
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Once we see a trigger-instance show up in the list, we can use the command `st2 trigger-instance get <trigger-instance-id>` (similar to what we did in a previous lesson with execution IDs) to view details about this trigger instance.
 Or if you're feeling lucky, you could use the below command with some bash-fu to get it for you :)
@@ -104,6 +104,6 @@ Or if you're feeling lucky, you could use the below command with some bash-fu to
 ```
 st2 trigger-instance get $(st2 trigger-instance list --trigger=napalm.InterfaceDown | grep napalm | tail -1 | awk '{ print $2}')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Remember those fields from earlier - `device` and `interface`? Those are filled out now, with the device and interface that we changed to create the event. These fields can now be passed on to other entities in StackStorm, like Rules, to drive very powerful, autonomous decision-making. Check out the next lab in this lesson for more on that!

--- a/lessons/lesson-15/stage5/guide.md
+++ b/lessons/lesson-15/stage5/guide.md
@@ -15,7 +15,7 @@ Our finished rule file can be seen here - continue for a walkthrough of each of 
 ```
 cat /antidote/lessons/lesson-15/stage5/replace_interface_config.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 The first part of a rule file is very similar to most other forms of YAML-based metadata in StackStorm. We have a few fields that describe the rule itself, such as its name, the pack it's in, etc:
 
@@ -58,7 +58,7 @@ Normally, rules would be located in the `rules/` directory of a pack, but we can
 ```
 st2 rule create /antidote/lessons/lesson-15/stage5/replace_interface_config.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 The tabular output shows us that StackStorm has ingested our new Rule definition and is ready to watch for new trigger-instances. Now that the rule is in place, any new instances of the trigger `napalm.InterfaceDown` will be handled by this rule. In the name of variety, let's trigger an event on `vqfx2`:
 
@@ -68,21 +68,21 @@ set interfaces em4 disable
 commit
 exit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', this)">Run this snippet</button>
 
 As with before, check the `trigger-instance` list until our new instance comes in. Again, this sensor works on a polling basis, so it may take a few seconds. Also note that if you went through the previous lab, our old trigger-instances will still be there, so pay attention to the timestamps.
 
 ```
 st2 trigger-instance list --trigger=napalm.InterfaceDown
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Similar to the relationship between `actions` and `executions`, as well as between `triggers` and `trigger-instances`, a specific instance of a Rule being matched is known as a `rule-enforcement`. Once we see our new `trigger-instance` appear in the previous command, we can list the `rule-enforcements` to make sure this trigger instance was picked up by our new rule:
 
 ```
 st2 rule-enforcement list
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 This is a very handy tool for seeing our new Rule in action. If you look at the output, you'll notice that the field `trigger_instance_id` shows the ID of the trigger-instance that was handled by this rule, as well as the  `execution_id` of the action execution that was created.
 
@@ -91,14 +91,14 @@ Remember how we retrieve execution details? `st2 execution get <execution-id>` w
 ```
 st2 execution get $(st2 execution list --action=napalm.loadconfig | grep napalm | tail -1 | awk '{ print $2}')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', this)">Run this snippet</button>
 
 Looks like our `loadconfig` action executed successfully - we can verify this at the CLI of `vqfx2` and see the interface that we just disabled, is back up and running:
 
 ```
 show interfaces em4
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', this)">Run this snippet</button>
 
 That's it for now! To recap:
 

--- a/lessons/lesson-15/stage6/guide.md
+++ b/lessons/lesson-15/stage6/guide.md
@@ -10,4 +10,4 @@ TBD
 ```
 
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>

--- a/lessons/lesson-16/stage1/guide.md
+++ b/lessons/lesson-16/stage1/guide.md
@@ -24,7 +24,7 @@ First, we need to install Jinja using `pip install jinja2`(it is preinstalled fo
 python
 from jinja2 import Template
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 As our first example, let's try to print the text `ge-0/0/0 has IP address 192.168.1.1`, but instead of simply printing this string,
 let's make the interface name and IP address more dynamic, by making them Jinja template variables.
@@ -42,7 +42,7 @@ variable into the `Template()` function to create our template object:
 ```
 ipaddr_template = Template('{{interface}} has IP address {{ip_address}}')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Now that our template is ready, we want to load the data in it. This can be done with the help of the `template.render()` function. `template.render()` will take the data you supply to the template variables and load it to the template. Check that out by running the below snippet.
 
@@ -52,7 +52,7 @@ interface_1 = ipaddr_template.render(interface='ge-0/0/0',
 print(str(interface_1))
 ```
 
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Since we've parameterized this template, we can put any values we want:
 
@@ -61,7 +61,7 @@ render_2 = ipaddr_template.render(interface='ge-0/0/1',
                                   ip_address='10.10.1.1')
 print(str(render_2))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 So, in summary:
 

--- a/lessons/lesson-16/stage2/guide.md
+++ b/lessons/lesson-16/stage2/guide.md
@@ -15,7 +15,7 @@ First, we want to start the Python interpreter and import `Environment` module f
 python
 from jinja2 import Environment
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In case you haven’t worked with python lists and dictionaries, here's a quick primer on lists and dictionaries, which we'll be using to populate more advanced
 template examples:
@@ -34,7 +34,7 @@ interfaces = [{'interface': 'ge-0/0/0', 'ip_address': '192.168.1.1'},
               {'interface': 'ge-0/0/1', 'ip_address': '10.10.1.1'},
               {'interface': 'fxp0', 'ip_address': '172.16.1.1'}]
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Each element in this list contains a dictionary with two keys: `interface` and `ip_address`.
 
@@ -55,7 +55,7 @@ ipaddr_template = env.from_string('''
 {{ item.interface }} has IP address {{ item.ip_address }}
 {% endfor %}''')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Let's talk a little bit about what we just did:
 
@@ -70,7 +70,7 @@ Once we have this template defined, we can render it like we did in previous sec
 render_1 = ipaddr_template.render(interfaces=interfaces)
 print(str(render_1))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Since all of our fields are keys of the dictionary `interfaces`, we only have to pass this in, and our template will access specific keys of that dictionary.
 
@@ -81,7 +81,7 @@ vlans = [{'vlan': 'VLAN10', 'vlan_id': 10},
          {'vlan': 'VLAN20', 'vlan_id': 20},
          {'vlan': 'VLAN30', 'vlan_id': 20}]
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Now we will learn how to use the `for` loop to format the template like a Junos CLI configuration.
 
@@ -97,13 +97,13 @@ vlans {
 }''')
 
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 After creating the template, lets supply the vlans data and see how it looks!
 ```
 vlan_config = str(vlan_config.render(vlans=vlans))
 print(vlan_config)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the next section, we'll add more decision-making power to our templates by using `if` and `set` statements.

--- a/lessons/lesson-16/stage3/guide.md
+++ b/lessons/lesson-16/stage3/guide.md
@@ -14,7 +14,7 @@ Again, we want to start the Python interpreter and import `Environment` module f
 python
 from jinja2 import Environment
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Here we are redefining `interface`, the list of dictionaries we defined in part 2.
 
@@ -24,7 +24,7 @@ interfaces = [{'interface': 'ge-0/0/0', 'ip_address': '192.168.1.1'},
               {'interface': 'fxp0', 'ip_address': '172.16.1.1'}]
 
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In Part2, we generated configurations for all interfaces that were passed to the template. Wwhat if you are only interested in generating the  configuration for the management interface? For this particular example we will be using the `if` condition. It is similar to the python `if` condition, except for some slight syntax differences:
 
@@ -57,7 +57,7 @@ render_1 = ipaddr_template.render(interfaces=interfaces)
 print(str(render_1))
 
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 
 The output shows that it just printed the entry of the management interface. Thus we learnt the power of `if` statements to filter out our data based on certain conditions.
@@ -98,6 +98,6 @@ render_2 = int_template.render(interfaces=interfaces)
 
 print(str(render_2))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the next stage, we'll dive deeper into using YAML files for defining variables for Jinja2 templates.

--- a/lessons/lesson-16/stage4/guide.md
+++ b/lessons/lesson-16/stage4/guide.md
@@ -21,7 +21,7 @@ We have a YAML file already stored in the machine for you! Lets start by taking 
 cd /antidote/lessons/lesson-16/stage4/
 cat part4.yml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 It is so much easier to read our data now! Now lets start with our lesson.
 
@@ -34,7 +34,7 @@ from jinja2 import Environment
 import yaml
 from pprint import pprint
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 The below snippet is used to import the data from the YAML file to our python code. The `open()` function opens our yaml file in the `read` mode and assigns it to the variable `yaml_file`. Just note that here we have only provided the name of our yaml file as it is in the same directory as our python code, in case it is in a different folder then you have to give the exact file path to the `open()`. The data from the YAML file can then be easily imported into Python simply by using `yaml.load()` function.
 
@@ -43,7 +43,7 @@ yaml_file = open('part4.yml', 'r')
 all_devices = yaml.load(yaml_file)
 pprint(all_devices)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Does this output look familiar? Its a list of dictionaries - the same as what we were using in previous sections! You already know what to do now. We start by creating a config template to set the `system hostname` and obtain the interface config:
 
@@ -66,7 +66,7 @@ interfaces {
 {% endfor %}
 ''')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Now that the template is defined we will render the config template for each device specified in the YAML file.
 
@@ -83,6 +83,6 @@ for dev_number, device in enumerate(all_devices, 1):
     print(str(render_1))
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 So now in the next stage we will learn how to import multiple Jinja templates from different directories and use it in your script. We will also see how to `include` those imported templates in one main template which can then be used to configure the device.

--- a/lessons/lesson-16/stage5/guide.md
+++ b/lessons/lesson-16/stage5/guide.md
@@ -14,7 +14,7 @@ We have already created a sample template file called `static_route.j2` in the s
 cd /antidote/lessons/lesson-16/stage5/
 cat dir1/static_route.j2
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Start the python shell and import the `FileSystemLoader` and `Environment` for loading the Jinja template. The `env` instance allows you to use an external Jinja template using FileSystemLoader:
 
@@ -24,7 +24,7 @@ from jinja2 import FileSystemLoader, Environment
 loader = FileSystemLoader('./dir1')
 env = Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 We will now store our template in the `route_template` variable and render it with the required values:
 
@@ -34,14 +34,14 @@ render_route = route_template.render(route='172.28.0.0/16',
                                      next_hop='10.13.106.1')
 print(str(render_route))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Quit the interactive python shell to view the other two templates that we are going to use for the next example.
 
 ```
 quit()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 ### Example: 2
 Below is the `l3_interface.j2` template stored in dir2 sub-directory.
@@ -49,14 +49,14 @@ Below is the `l3_interface.j2` template stored in dir2 sub-directory.
 ```
 cat dir2/l3_interface.j2
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Below is the `device_config.j2` template stored in our local directory. We will treat `device_config.j2` as our main template and include `l3_interface.j2` and `static_route.j2`.
 
 ```
 cat device_config.j2
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Notice the keyword `include`, it is used to include the other external template files into a Jinja template. Below is the syntax for `include`:
 
@@ -80,7 +80,7 @@ render_device = device_template.render(route='172.28.0.0/16',
 
 print(str(render_device))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Good Job! You are now ready to render your own network configuration templates!
 

--- a/lessons/lesson-17/stage1/guide.md
+++ b/lessons/lesson-17/stage1/guide.md
@@ -14,35 +14,35 @@ We refer to a group of directories and files managed by Git as a "repository" (o
 ```
 mkdir myfirstrepo/ && cd myfirstrepo/
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Right now, `myfirstrepo` is just a regular directory. We can "initialize" a new git repository in this directory using `git init`:
 
 ```
 git init
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 A Git repository is nothing without some files to manage. Let's create a text file and add some text to it:
 
 ```
 echo "this is some text" > newfile.txt
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 We can use `git status` to see Git's current view of the repository:
 
 ```
 git status
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Note that while the file exists, Git is listing it as "untracked", meaning it's not actually part of the Git repo. In order to formally include a file in a Git repository, we must commit it. In order to commit it, we must first add it to "staging". This is done using `git add`:
 
 ```
 git add newfile.txt
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Now that the file is in staging, we can create our first commit! A commit is a way of marking a particular state of a repository, saying "I would like to remember what things were like at this point in time, so I can go back to it if I need to. Often, a commit is made when a developer makes a meaningful change to some code, or an NRE updates a YAML file with a new set of variables for a switch install. No matter the use case, **the commit is king**.
 

--- a/lessons/lesson-19/stage1/guide.md
+++ b/lessons/lesson-19/stage1/guide.md
@@ -22,7 +22,7 @@ If you've ever worked on a Linux system, or maybe an Apple computer, you might h
 ```
 curl https://google.com
 ```
-<!-- <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button> -->
+<!-- <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button> -->
 
 This is effectively the same as what your browser would do if you were to navigate to Google there - it requests a resource from the remote server, and the server responds with the HTML you see in your terminal. Of course, the intention is that the browser would then render this HTML into something we can look at. `curl` performs no such function, so we just get the raw HTML.
 
@@ -34,6 +34,6 @@ curl \
     http://vqfx1:8080/rpc/get-interface-information \
     --header "Accept: application/json"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 This output is a bit different than the first output. This isn't HTML at all - it's a very efficient format called JSON, or "Javascript Object Notation". It's the de-facto standard for the vast majority of REST APIs.

--- a/lessons/lesson-19/stage2/guide.md
+++ b/lessons/lesson-19/stage2/guide.md
@@ -16,7 +16,7 @@ First, we want to start the Python interpreter:
 ```
 python
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 You'll notice the prompt has changed to `>>>` to indicate that we're no longer in the Bash prompt, but rather in the Python interpreter. From now on, every command we run is valid Python we can also place into a `.py` file and run as a script.
 
@@ -27,7 +27,7 @@ import requests
 headers = {'Accept': 'application/json'}
 resp = requests.get('http://vqfx1:8080/rpc/get-interface-information', headers=headers, auth=('antidote', 'antidotepassword'))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 That's it - in three lines of Python, you queried the REST API of a network device, and we can now work with the data returned to us.
 
@@ -43,6 +43,6 @@ for interface in interfaces:
 
 print("There are %d interfaces in this device" % len(interfaces))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the next stage, we'll dive a little deeper into a specific API and figure out what other kinds of information we can send or retrieve.

--- a/lessons/lesson-21/stage1/guide.md
+++ b/lessons/lesson-21/stage1/guide.md
@@ -13,7 +13,7 @@ Before we run this script, we'll have to start the SIP phone software located on
 ```
 ./phone.sh
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('sipphone', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('sipphone', this)">Run this snippet</button>
 
 ...
 
@@ -27,7 +27,7 @@ Now let's get the IP of the phone by querying the SIP PBX.  Click the button bel
 cd /antidote/lessons/lesson-21
 ./get-phone-ip-from-ext.py --host=asterisk --port=8088 --username=admin --password=admin --phone=1107
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 And there it is!  For many enterprise customers, getting the IP address of a software or hardware client such as a phone, a virtual-machine host, a chat client, or a storage element can be difficult and time consuming. Having a script such as this where you can pass in non-network data, such as the extension number, to retrieve network data, such as an IP, can save time and frustration!
 

--- a/lessons/lesson-22/stage1/guide.md
+++ b/lessons/lesson-22/stage1/guide.md
@@ -18,7 +18,7 @@ If you've ever worked on a Linux system, or maybe an Apple computer, you might h
 ```
 curl https://google.com
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 What we've just done is effectively the same as what your browser would do if you were to navigate to Google there - it requests a resource from the remote server, and the server responds with the HTML you see in your terminal. Of course, the intention is that the browser would then render this HTML into something we can look at. `curl` performs no such function, so we just get the raw HTML.
 
@@ -30,6 +30,6 @@ curl \
     http://vqfx1:8080/rpc/get-interface-information \
     --header "Accept: application/json"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 

--- a/lessons/lesson-23/stage1/guide.md
+++ b/lessons/lesson-23/stage1/guide.md
@@ -12,21 +12,21 @@ Let's learn a few important commands. We have a `linux1` system spun up in the t
 ```
 pwd
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 This is our "home" directory - the directory we start in by default when logged in as this user. Let's create a new directory called `mydirectory` by using the `mkdir` command:
 
 ```
 mkdir newdirectory
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 No matter which directory you're currently in, you'll periodically want to know what it contains. For instance, we're still in our home directory, so we can use `ls` with a few flags to list all the files in this directory.
 
 ```
 ls -lha
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 You may notice the flags `l`, `h`, and `a` are used here. These are optional, but a very common addition to `ls` because they do a few useful things for us:
 
@@ -40,14 +40,14 @@ Many systems alias this command to `ll` so you don't have to type out all the fl
 alias ll="ls -lha"
 ll
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Note that by default, `ls -lha` (or our new alias `ll`) assumes you want to list the files (and directories) in the directory you're currently in, but we can provide a directory after the command to list the files in that location (assuming we have permissions to do so):
 
 ```
 ll /
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 This command listed all the files in the directory `/`, which is known as the "root directory". This is the highest point in the directory structure - there's nothing above this. All of the files and directories you see in this output
 
@@ -56,7 +56,7 @@ While we were able to list the contents of the root directory, our present worki
 ```
 cd newdirectory/
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 This is an empty directory (hint: try running `ll` here) so let's create a file. The `touch` command creates a new, empty file with the name you specify:
 
@@ -64,7 +64,7 @@ This is an empty directory (hint: try running `ll` here) so let's create a file.
 touch newfile.txt
 ll
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Let's take a closer look at the output of `ll`. We can see the file we created, but we see three entries, instead of just one.
 
@@ -84,4 +84,4 @@ The latter, `..`, is super useful for being able to just "go up a directory", wi
 cd ..
 ll
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>

--- a/lessons/lesson-24/stage1/guide.md
+++ b/lessons/lesson-24/stage1/guide.md
@@ -30,7 +30,7 @@ In Junos (as well as most other implementations), NETCONF is run over the Secure
 sshpass -p antidotepassword \
 ssh -o StrictHostKeyChecking=no antidote@vqfx -s netconf
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 > While this isn't how you'd normally use NETCONF in the real world, it does allow us to tinker around with the protocol a bit and see how it works. Normally, you'd use a framework like PyEZ which abstracts these details away.
 
@@ -41,14 +41,14 @@ To get system uptime, use `<get-system-uptime-information>` and embedded it in `
 ```
 <rpc><get-system-uptime-information/></rpc>
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Finally, to close the session, use `<close-session>` tag.
 
 ```
 <rpc><close-session/></rpc>
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### What's next?
 

--- a/lessons/lesson-24/stage2/guide.md
+++ b/lessons/lesson-24/stage2/guide.md
@@ -21,7 +21,7 @@ We'll enter the python shell, and then import the appropriate module:
 python
 from jnpr.junos import Device
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 After that, create a Device object by providing hostname, username and password for authenticating to vQFX device, and then call the `open()` function to make a NETCONF connection.
 
@@ -29,7 +29,7 @@ After that, create a Device object by providing hostname, username and password 
 dev = Device('vqfx', user='antidote', password='antidotepassword')
 dev.open()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 This is a much simpler way to accomplish the same thing we did manually in the previous section!
 
@@ -41,7 +41,7 @@ Next, we'll use a special `pprint()` function to print this device's basic infor
 from pprint import pprint
 pprint(dev.facts)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The `dev.facts` dictionary consolidates the output of multiple RPC get requests, e.g. show chassis routing-engine, show version, show virtual-chassis, etc. Under the hood, when you first time access the `dev.facts` attribute, PyEZ will execute corresponding RPC requests to collect information likes host name, software version, serial number, etc. 
 
@@ -56,7 +56,7 @@ In the case of Junos, you can just add the pipe ` | display xml rpc` to the `sho
 ```
 show system uptime | display xml rpc
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 From the output, we know the XML tag of `show system uptime` command is `<get-system-uptime-information>`.
 
@@ -67,7 +67,7 @@ Finally, use this as the append it to the `dev.rpc` object, it will return XML o
 ```
 uptime = dev.rpc.get_system_uptime_information()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 There is no output from above snippet, the code just saves response to `uptime` variable. You will learn how to display and extract useful information from returned variable later.
 
@@ -80,7 +80,7 @@ There is a similar mechanism to specify those arguments in a PyEZ RPC call.  The
 ```
 show interfaces em3 statistics | display xml rpc
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 From the Junos output, you can see two types of arguments:
   - `<interface-name>em3</interface-name>` key-value pair, key is `interface-name`, and value is the actual name of target interface
@@ -96,6 +96,6 @@ You should now be able to determine the format of RPC call, let's do it:
 intf = dev.rpc.get_interface_information(
     interface_name='em3', statistics=True)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Again, the output is saved to `intf` variable, and there should be no output in the terminal. You'll learn how to extract information in next section.

--- a/lessons/lesson-24/stage3/guide.md
+++ b/lessons/lesson-24/stage3/guide.md
@@ -19,14 +19,14 @@ dev = Device('vqfx', user='antidote', password='antidotepassword', normalize=Tru
 dev.open()
 intf = dev.rpc.get_interface_information()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 From the `type()` function output, we know the object type is `lxml.etree._Element`:
 
 ```
 type(intf)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 To display the `xml.etree` object as XML string, we have to import the `etree` module from the `lxml` library (a popular Python library for dealing with XML),
 and then use the `dump()` function to convert our XML etree object to an XML string.
@@ -35,7 +35,7 @@ and then use the `dump()` function to convert our XML etree object to an XML str
 from lxml import etree
 etree.dump(intf)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Extract data
 
@@ -50,7 +50,7 @@ result is a list contains all `<physical-interface>` element nodes.
 ```
 intf.xpath('physical-interface')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 ---
 
@@ -61,7 +61,7 @@ To check how many physical interface is in the Junos device, query `len()` of th
 ```
 len(intf.xpath('physical-interface'))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 **Result:** 28 physical interfaces
 
@@ -72,7 +72,7 @@ Using the `xpath()` condition feature, we can filter on only physical interfaces
 ```
 len(intf.xpath('physical-interface[mtu="1514"]'))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 **Result:** 15 physical interfaces
 
@@ -83,7 +83,7 @@ Out of 15 physical interfaces with an MTU of 1514, how many have been configured
 ```
 len(intf.xpath('physical-interface[mtu="1514"]/logical-interface'))
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 **Result:** 5 logical interfaces
 
@@ -101,6 +101,6 @@ for ifl in intf.xpath('physical-interface[mtu="1514"]/logical-interface'):
     ))
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Now that you've learned how to extract the desired information from RPC responses, in the next section we'll talk about configuration provisioning using PyEZ.

--- a/lessons/lesson-24/stage4/guide.md
+++ b/lessons/lesson-24/stage4/guide.md
@@ -16,7 +16,7 @@ from jnpr.junos import Device
 dev = Device('vqfx', user='antidote', password='antidotepassword')
 dev.open()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 We use the `get_config()` function to get Junos configuration. The optional `options` argument
 allows us to provide some additional detail for the kind of configuration we're requesting, such as candidate vs committed, default vs inherit, etc.
@@ -28,14 +28,14 @@ Let's use the `get_config()` function below and provide options to get the inher
 config = dev.rpc.get_config(
     options={'database':'committed', 'inherit':'inherit'})
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Now that the configuration is stored in the `config` variable, we can use the `findtext()` function to get our device's host name:
 
 ```
 config.findtext('system/host-name')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 We can also provide another optional argument for `get_config()` called `filter_xml`. This is used to limit the returned configuration hierarchy. This parameter requires us to pass
 in an XML `etree` object, so to build this, we use the `lxml` package we used previously. This package's `E()` function can be supplied inline to get us an `etree` object to provide to `filter_xml`.
@@ -55,7 +55,7 @@ config = dev.rpc.get_config(
 )
 print(config.text)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The `filter_xml` argument is useful when the Junos device contains a huge config; the retrieval of a very large config can take a long time and is CPU intensive. With this filter, we can retrieve only what we need.
 
@@ -67,7 +67,7 @@ To work with a Junos configuration, first import `Config` module from `jnpr.juno
 from jnpr.junos.utils.config import Config
 dev.bind(cu=Config)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 After that, use the `load()` function to load target config; it supports both text and set format. In the below example, we're providing a config snippet to set Junos device's host name to 'vqfx_new':
 
@@ -78,7 +78,7 @@ system {
 }'''
 dev.cu.load(config_text, format='text')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 In this example, we provided the configuration as a multi-line string literal, stored in `config_text`. You can (and should) use <a href="/labs/?lessonId=16&lessonStage=1" target="_blank">Jinja.</a> to create configuration snippets from a template, and pass the result into `dev.cu.load`, but this is sufficient for a quick example.
 
@@ -89,7 +89,7 @@ After loading the config, you can see the current candidate changes (similar to 
 ```
 dev.cu.pdiff()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 
 Loading the configuration is only part of the story. Just like on the CLI, when we make a change to the config, we have to commit it to make those changes take effect:
@@ -97,13 +97,13 @@ Loading the configuration is only part of the story. Just like on the CLI, when 
 ```
 dev.cu.commit()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Finally, we can go to our Junos CLI to verify the last configuration change:
 
 ```
 show configuration | compare rollback 1
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 By now, you should know all the common operations on Junos automation in PyEZ. In the next section, we'll look at one more tool in the PyEZ arsenal - Tables and Views.

--- a/lessons/lesson-24/stage5/guide.md
+++ b/lessons/lesson-24/stage5/guide.md
@@ -17,7 +17,7 @@ There are some predefined OpTables and ConfigTables, located in the `op` and `re
 ls /usr/local/lib/python2.7/dist-packages/jnpr/junos/op
 ls /usr/local/lib/python2.7/dist-packages/jnpr/junos/resources
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### PyEZ OpTable
 
@@ -26,7 +26,7 @@ ls /usr/local/lib/python2.7/dist-packages/jnpr/junos/resources
 ```
 cat /usr/local/lib/python2.7/dist-packages/jnpr/junos/op/routes.yml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 PyEZ allows us to easily use these existing tables by importing them as Python modules. To import an OpTable like `RouteTable`, first import the the dictionary name defined in the YAML file that has the `rpc` key; the name usually ends with 'Table'. The Python import path is constructed from the file name path - change `/` to `.` and remove the extension.
 
@@ -34,7 +34,7 @@ PyEZ allows us to easily use these existing tables by importing them as Python m
 python
 from jnpr.junos.op.routes import RouteTable
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next, create a Table instance and use the device's `bind()` function to associate the Table with the Device.
 
@@ -44,21 +44,21 @@ dev = Device('vqfx', user='antidote', password='antidotepassword')
 dev.open()
 dev.bind(routes=RouteTable)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The definition for `RouteTable` specifies the RPC function to retrieve routes, which is `<get-route-information>`. This makes it simpler for us in Python: we need only call the `get()` function. This accepts the same arguments as `dev.rpc.get_route_information()`. Let's pass `table='inet.0'` to specify the default route table; it is the same as the CLI command `show route table inet.0`.
 
 ```
 dev.routes.get(table='inet.0')
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Now, you can show all collected routes by accessing the dictionary keys:
 
 ```
 dev.routes.keys()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 For each route, access its dictionary key to get the route information:
 
@@ -67,7 +67,7 @@ dev.routes['10.0.0.0/24'].keys()
 dev.routes['10.0.0.0/24'].via
 dev.routes['10.0.0.0/24'].protocol
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 To display all of the routing information, we can use a `for` loop to iterate over the Tables object.
 
@@ -76,7 +76,7 @@ for route in dev.routes:
     print(route.key, route.protocol, route.via, route.age, route.nexthop)
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 PyEZ OpTable enables users with **NO** XML knowledge to manage and automate Junos devices. As illustrated in above examples, you can retrieve device's route table without any XML elements.
 
@@ -92,7 +92,7 @@ This section takes the `StaticRouteTable` ConfigTable as an example; it is defin
 exit()
 cat /usr/local/lib/python2.7/dist-packages/jnpr/junos/resources/staticroutes.yml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Similar to OpTable, the first step is to import the dictionary name defined in YAML file that has `set` key, the name usually ends with 'Table'.
 
@@ -100,7 +100,7 @@ Similar to OpTable, the first step is to import the dictionary name defined in Y
 python
 from jnpr.junos.resources.staticroutes import StaticRouteTable
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next, create a Table instance and use the `bind()` function to associate with the Device.
 
@@ -110,7 +110,7 @@ dev = Device('vqfx', user='antidote', password='antidotepassword')
 dev.open()
 dev.bind(route=StaticRouteTable)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The dictionary `StaticRouteView` in the YAML file determines the available settings for this ConfigTable. As in the terminal output, `route_name` and `hop` are defined, and we can assign values to these attributes:
 
@@ -118,14 +118,14 @@ The dictionary `StaticRouteView` in the YAML file determines the available setti
 dev.route.route_name = '192.168.100.0/24'
 dev.route.hop = '10.0.0.2'
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 11)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 After we've configured one set of data, we can call the `append()` function to add it to our config:
 
 ```
 dev.route.append()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 12)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 If there is additional data, set them again and call another `append()`.
 
@@ -134,21 +134,21 @@ dev.route.route_name = '192.168.200.0/24'
 dev.route.hop = '10.0.0.2'
 dev.route.append()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 13)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Finally, when finished appending all new configs, call `set()` function:
 
 ```
 dev.route.set()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 14)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 This performs a configuration commit on our device and applies the changes to the running configuration. Again, we can verify new config is applied on the Junos CLI:
 
 ```
 show configuration |compare rollback 1
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 15)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 ConfigTable enables users to provision Junos config without XML elements. You don't have to prepare the configuration file or any `set` commands, instead, just simply configure dictionary values and then call `append()` and `set()` function.
 

--- a/lessons/lesson-25/stage1/guide.md
+++ b/lessons/lesson-25/stage1/guide.md
@@ -36,13 +36,13 @@ set system services extension-service notification port 1883 allow-clients addre
 set system services extension-service request-response grpc clear-text port 32767
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 We can check the listening port to verify the notification and gRPC service are enabled.
 
 ```
 show system connections | match LISTEN | match "\.1883|\.32767"
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Now the Junos OS device is ready for off-box JET applications and it's time to get some action!  In the next chapter, we'll go through the notifiaction mechanism and collect some events from the MQTT event bus.

--- a/lessons/lesson-25/stage2/guide.md
+++ b/lessons/lesson-25/stage2/guide.md
@@ -31,7 +31,7 @@ First of all, go to the Python interactive prompt and import the MQTT module.
 python
 import paho.mqtt.client as mqtt
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 After that, create a MQTT client object. Then define the `on_connect` callback function, which is triggered once the client connects to the JET MQTT broker, to subscribe the event. Here, we will subscribe to the topic `/junos/events/kernel/interfaces/ifa/add` which includes all new interfaces address events.
 At last we bind the on_connect function to the client object.
@@ -44,7 +44,7 @@ def on_connect(client, userdata, flags, rc):
 
 client.on_connect = on_connect
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next, define `on_message` callback function, which is triggered whatever a message is received, to print the notification message payload. Then we bind the on_message function to the client object.
 
@@ -54,7 +54,7 @@ def on_message(client, userdata, msg):
 
 client.on_message = on_message
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Finally, instruct the client to connect to vQFX TCP port 1883 we configured in previous stage, and start the main event loop function `loop_forever()`  to wait for events.
 
@@ -62,7 +62,7 @@ Finally, instruct the client to connect to vQFX TCP port 1883 we configured in p
 client.connect('vqfx', 1883, 60)
 client.loop_forever()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The client is now ready to received JET notification event. It's normal that you don't see a prompt back - this command runs endlessly until stopped.
 
@@ -75,7 +75,7 @@ configure
 set interfaces xe-0/0/0 unit 0 family inet address 192.168.10.1/24
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Once the commit is completed, Eventd will receive the new IFA event and deliver it to all clients who subscribed the IFA topic.
 

--- a/lessons/lesson-25/stage3/guide.md
+++ b/lessons/lesson-25/stage3/guide.md
@@ -28,21 +28,21 @@ To save time, the IDL file is pre-downloaded already. First we need to unarchive
 cd /antidote/lessons/lesson-25
 tar -xzf jet-idl-17.4R1.16.tar.gz
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next, compile the protocol buffer into python stub code:
 
 ```
 python -m grpc_tools.protoc -I./proto --python_out=. --grpc_python_out=. ./proto/*.proto
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Verify the python stub class are generated:
 
 ```
 ls  -l *pb2*
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The python stub class is now ready, the next step we will use it to perform gRPC to the Junos device.
 
@@ -61,7 +61,7 @@ import authentication_service_pb2_grpc
 import rib_service_pb2 as rib
 import rib_service_pb2_grpc
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Now we create a gRPC connection to the vQFX and perform the authentication.
 
@@ -77,14 +77,14 @@ response = auth_stub.LoginCheck(
     )
 )
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Print the response to verify the connection is established.
 
 ```
 print(response.result)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Now, we can call the Route Add API to insert a static route 192.168.20.0/24 with next-hop 192.168.10.2 dynamically.
 
@@ -107,19 +107,19 @@ result = rib_stub.RouteAdd(
     )
 )
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Print the response to verify the route add status.
 ```
 print(result)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 At last, verify the route is being added by doing CLI command `show route` on the vQFX.
 
 ```
 show route table inet.0
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Easy isn't it? With Juniper JET you can dynamically manage device configuration and runtime status such as route tables, ACL, interface status, etc without touching the CLI at all. This API interfaces open a whole new world for network applications. For more information about the API, please refer to the <a href="https://www.juniper.net/documentation/en_US/jet18.2/topics/concept/jet-service-apis-overview.html" target="_blank">JET Service APIs guide</a>

--- a/lessons/lesson-25/stage4/guide.md
+++ b/lessons/lesson-25/stage4/guide.md
@@ -35,14 +35,14 @@ response = auth_stub.LoginCheck(
     )
 )
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 We simulate a neighboring device by creating a new routing instance in the vQFX. Interface xe-0/0/0 and xe-0/0/1 is connected together, so on vQFX we can ping from the master routing instance to 192.168.10.2, which is the IP address in the routing instance "VR". Let's try to verify it:
 
 ```
 ping 192.168.10.2 count 3
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 #### Create ACL via JET
 Now, we use the JET firewall API to create a new firewall filter call `filter-by-jet`. This filter contains two terms, the first one is to log and permit ICMP traffic, and the last one is to log and discard all traffic.
@@ -79,14 +79,14 @@ filter = fw.AccessList(
 )
 result = fw_stub.AccessListAdd(filter)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 We can verify the firewall filter is actually added to the data plane by using the PFE command.
 
 ```
 request pfe execute target fpc0 timeout 0 command "show firewall" | no-more
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 #### Apply ACL to interface via JET
 Now, we apply the firewall filter to interface xe-0/0/0.
@@ -102,7 +102,7 @@ result = fw_stub.AccessListBindAdd(
     )
 )
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 
 #### Verify the ACL
@@ -113,20 +113,20 @@ To verify the firewall ACL is being applied, we ping 192.168.10.2 again and then
 ping 192.168.10.2 count 3
 show firewall log
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Then try to SSH to 192.168.10.2, it should fail.
 
 ```
 ssh 192.168.10.2
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Press `Ctrl-C` now to stop the SSH, and the check the firewall log again.
 
 ```
 show firewall log
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 This concludes our Junos JET gRPC demostration. In the next lesson are we going explore closed loop automation by employing both JET Notification Service and JET RPC.

--- a/lessons/lesson-25/stage5/guide.md
+++ b/lessons/lesson-25/stage5/guide.md
@@ -17,7 +17,7 @@ To save time, we have already put the JET firewall API code we created in stage 
 cd /antidote/lessons/lesson-25
 cat add_firewall_filter.py
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Again, we repeat what we have done in previous stage - compile the IDL package, go to Python interactive prompt, import the required module.
 
@@ -32,7 +32,7 @@ import paho.mqtt.client as mqtt
 from add_firewall_filter import add_firewall_filter
 
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Then same as stage 2, we create a MQTT client and define `on_connect` callback function to subscribe to the topic "IFA add events" once the client connect to the JET MQTT broker.
 
@@ -44,7 +44,7 @@ def on_connect(client, userdata, flags, rc):
 
 client.on_connect = on_connect
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next, define `on_message` callback function, to call the `add_firewall_filter` function if the new IP address is in the public range. After that, connect to vQFX and start to wait for event.
 
@@ -65,7 +65,7 @@ client.on_message = on_message
 client.connect('vqfx', 1883, 60)
 client.loop_forever()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Testing the close loop automation
 To validate our automation, We simulate another neighboring device by creating one more routing instance in the vQFX. Interface xe-0/0/2 and xe-0/0/3 is connected together, and a public IP address `20.1.1.2/24` is pre-configured on xe-0/0/3 which is in routing instance `VR2`
@@ -77,7 +77,7 @@ configure
 set interfaces xe-0/0/2 unit 0 family inet address 20.1.1.1/24
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Verify the message `Apply firewall filter ...` is shown in `linux` terminal.
 
@@ -87,7 +87,7 @@ To verify the firewall ACL is being applied, we ping 20.1.1.2 again and then che
 ping 20.1.1.2 count 3
 show firewall log
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 The firewall log should capture the ping traffic. This verifies a firewall filter can be automatically provisioned to the interface dynamically without modifying the Junos configuration.
 

--- a/lessons/lesson-26/stage1/guide.md
+++ b/lessons/lesson-26/stage1/guide.md
@@ -27,7 +27,7 @@ The OpenConfig package has already been uploaded to our virtual QFX image, so we
 request system software add /var/db/vmm/junos-openconfig-0.0.0.10-1-signed.tgz no-validate
 yes
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 _Starting in Junos 18.3R1, the OpenConfig package is bundled with Junos image and therefore you do not need to install it separately._
 
@@ -38,14 +38,14 @@ Once the installation has completed, you can verify it with the `show version` c
 ```
 show version
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 After installing the OpenConfig package, a few config stanzas with prefix `openconfig-` are added automatically. Let's take a look on the new config knob:
 
 ```
 show configuration openconfig-
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 This verifies the OpenConfig package is installed properly.
 

--- a/lessons/lesson-26/stage2/guide.md
+++ b/lessons/lesson-26/stage2/guide.md
@@ -17,7 +17,7 @@ configure
 set openconfig-interfaces:interfaces interface xe-0/0/0 subinterfaces subinterface 0 openconfig-if-ip:ipv4 addresses address 192.168.10.1/24
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 
 Verify the new interface is created.
@@ -25,14 +25,14 @@ Verify the new interface is created.
 ```
 show interfaces terse xe-0/0/0
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 As discussed in chapter 1, the Junos OpenConfig package contains scripts to translate OpenConfig based configuration into Junos format. We can show the  translated Junos config with the following command:
 
 ```
 show configuration | display translation-scripts translated-config | no-more
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 As you can see the fundamental data values are the same across OpenConfig and Junos Config, only the schema differs.
 
@@ -44,7 +44,7 @@ Now, let's try to configure a new BGP neighbor with Openconfig using Netconf. Fi
 cd /antidote/lessons/lesson-26
 cat openconfig-bgp.conf
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 As you can see, the OpenConfig BGP schema contains common data that BGP requires. This configuration should be able to be provisioned to any network devices that support netconf with OpenConfig.
 
@@ -61,7 +61,7 @@ dev = Device('vqfx', user='antidote', password='antidotepassword')
 dev.bind(cu=Config)
 dev.open()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next, we load the configuration, print the diff, and  commit:
 
@@ -70,7 +70,7 @@ dev.cu.load(path='openconfig-bgp.conf', format='text')
 dev.cu.pdiff()
 dev.cu.commit()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Verify a new BGP neighbor is being created.
 **Note:** _the peering neighbor doesn't exist in the setup, therefore the BGP state is expected to be `Connect` or `Active`_
@@ -78,14 +78,14 @@ Verify a new BGP neighbor is being created.
 ```
 show bgp summary
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Again we inspect the translated Junos config:
 
 ```
 show configuration | display translation-scripts translated-config | no-more
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Now you can see that OpenConfig is vendor-neutral and therefore this exercise can be applied to any other vendor that also supports OpenConfig (_by using a vendor neutral NetConf Client_).
 

--- a/lessons/lesson-26/stage3/guide.md
+++ b/lessons/lesson-26/stage3/guide.md
@@ -31,14 +31,14 @@ Let's take a look on the YANG file first.
 cd /antidote/lessons/lesson-26
 cat vpn-services.yang
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 For the translation script, it supports both SLAX and Python language.  We're using Python language in this lesson as it's familiar to most people.  Different with commit script, to improve the efficiency, it processes the delta configuration only and therefore the translation script logic should take care the addition and removal of config knob. Let's take a look on the translation script.
 
 ```
 cat vpn-services.py
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 To install the custom YANG module, we have to copy both `vpn-services.yang` and `vpn-services.py` to vQFX:
 
@@ -47,14 +47,14 @@ To install the custom YANG module, we have to copy both `vpn-services.yang` and 
 ```
 sshpass -p antidotepassword scp -o StrictHostKeyChecking=no vpn-services.* antidote@vqfx:~
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Then we install the custom YANG module by `request system yang add` command:
 
 ```
 request system yang add package vpn-services module vpn-services.yang translation-script vpn-services.py
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 After the installation completed, press `ENTER` key a few times to acknowledge the `cli` process restart request.
 
@@ -64,6 +64,6 @@ Use the following command to verify the YANG package `vpn-services` is installed
 ```
 show system yang package vpn-services
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Now, the Junos device is ready to be provisioned using the custom yang module. In next lesson, we will configure some L3VPN services using the new `vpn-services` config knob.

--- a/lessons/lesson-26/stage4/guide.md
+++ b/lessons/lesson-26/stage4/guide.md
@@ -24,7 +24,7 @@ set static-route route 192.168.0.0/17 next-hop 192.168.10.254
 set static-route route 192.168.128.0/17 next-hop 192.168.10.253
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 #### Config Verification
 
@@ -33,14 +33,14 @@ We can also check the translated configuration:
 ```
 show configuration | display translation-script translated-config | no-more
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 Verify a new routing instance is created.
 
 ```
 show route table CustomerA.inet.0
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 #### Config Custom YANG Configuration using NETCONF
 Now, let's try to create another L3VPN instance using NETCONF. Firstly, go to Python interactive prompt, load PyEZ module and create a Junos device object:
@@ -53,7 +53,7 @@ dev = Device('vqfx', user='antidote', password='antidotepassword')
 dev.bind(cu=Config)
 dev.open()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Then we load the configuration, print the diff, and commit:
 
@@ -62,14 +62,14 @@ dev.cu.load(path='vpn-services.conf', format='text')
 dev.cu.pdiff()
 dev.cu.commit(timeout=600)
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Verify the translated config:
 
 ```
 show configuration | display translation-script translated-config | no-more
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx', this)">Run this snippet</button>
 
 To conclude we demostrated how to provision Junos device using custom YANG modules via CLI and NETCONF. Custom YANG modules is flexible that it can be used to define custom service oriented configration models to suit your business needs. Please feel free to to modify the configuration by yourself and see how the translation script helps you to provision the corresponding Junos configuration.
 

--- a/lessons/lesson-29/stage1/guide.md
+++ b/lessons/lesson-29/stage1/guide.md
@@ -121,7 +121,7 @@ Let's examine our python file `substring.py`:
 ```
 cat /antidote/lessons/lesson-29/stage1/substring.py
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 It contains a single function `is_a_substring` that takes in two string arguments - str1 and str1. It then returns True if str1 is a substring of str2.
 
@@ -129,7 +129,7 @@ Let's check out our Robot file now:
 ```
 cat /antidote/lessons/lesson-29/stage1/chapter1_eg1.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Under the Settings, we import our python file `substring.py` as a Library.
 
@@ -141,7 +141,7 @@ We'll go ahead and start our test-cases:
 robot /antidote/lessons/lesson-29/stage1/chapter1_eg1.robot
 ```
 
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 11)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 As expected, test-cases `Check Equal1`, `Check Equal2`, `Check Substring2` fails, and `Check Equal1`, `Check Substring1` pass. Since all the test-cases did not pass, the test-suite result is "Fail".
 

--- a/lessons/lesson-29/stage2/guide.md
+++ b/lessons/lesson-29/stage2/guide.md
@@ -27,7 +27,7 @@ Let's examine the file `JunosDevice.py` and understand the different functions.:
 ```
 cat /antidote/lessons/lesson-29/stage2/JunosDevice.py
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Here's some detail around the functions we'll be using in our Robot tests from this library:
 
@@ -77,7 +77,7 @@ Let's examine our Robot test-case file `chapter2_eg1.robot`:
 ```
 cat /antidote/lessons/lesson-29/stage2/chapter2_eg1.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the `Settings` table, we define our private custom library `JunosDevice.py`:
 
@@ -125,7 +125,7 @@ Execute this test suite by running the below command (note the command line vari
 ```
 robot --variable HOST:vqfx1 --variable USER:antidote --variable PASSWORD:antidotepassword /antidote/lessons/lesson-29/stage2/chapter2_eg1.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 If both the test-cases succeed, the entire test-suite passes. If any of them fails, then the corresponding test-case raises an Exception which displays why the test case failed.
 

--- a/lessons/lesson-29/stage3/guide.md
+++ b/lessons/lesson-29/stage3/guide.md
@@ -41,7 +41,7 @@ Let's examine our Robot test-case file `chapter3_eg1.robot`:
 ```
 cat /antidote/lessons/lesson-29/stage3/chapter3_eg1.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 You must have noticed the new `Keywords` table in our robot file. Inside this table, two new keywords have been defined, Log Facts and Validate Facts. Allow me to explain each of these separately.
 
@@ -86,7 +86,7 @@ Notice that both of the test cases are using the previously defined user keyword
 ```
 robot --variable HOST:vqfx1 --variable USER:antidote --variable PASSWORD:antidotepassword /antidote/lessons/lesson-29/stage3/chapter3_eg1.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 ### Test Case 2
 
@@ -95,7 +95,7 @@ Let's examine our Robot test-case file `chapter3_eg2.robot`:
 ```
 cat /antidote/lessons/lesson-29/stage3/chapter3_eg2.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Note that the robot file only has two sections and inside the `Settings` section, a separate robot file has been imported using the `Resource` setting. This file is called the resource file. Also observe that there are two other settings present inside the `Settings` table, namely "Test Setup" and "Test Teardown". These settings call keywords which have been originally defined in the resource file.
 
@@ -103,7 +103,7 @@ Let's now check out our resource file `chapter3_resource.robot`:
 ```
 cat /antidote/lessons/lesson-29/stage3/chapter3_resource.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Notice that this time, we have declared all the required variables in the "Variables" section of the resource file. What this means is that we will no longer have to pass the variable names while running the robot file.
 
@@ -112,6 +112,6 @@ Also, observe that three user keywords have been defined under the "Keywords" se
 ```
 robot /antidote/lessons/lesson-29/stage3/chapter3_eg2.robot
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 That's it for now - have fun writing tests for your network infrastructure!

--- a/lessons/lesson-30/stage1/guide.md
+++ b/lessons/lesson-30/stage1/guide.md
@@ -17,7 +17,7 @@ The Salt Master and the Salt Minion can run on seprate machines or can run on th
 service salt-master restart
 service salt-minion restart
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 Once the Salt minion is running, it will send its public key to the Salt Master. We can view the key's status by executing "salt-key -L".
 
@@ -25,14 +25,14 @@ Once the Salt minion is running, it will send its public key to the Salt Master.
 ```
 salt-key -L
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 Let's accept the Salt Minion's public key using the command
 
 ```
 salt-key --accept="minion" -y
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 Once this is done, the Salt Master will be able to communicate with the Salt Minion and issue remote commands.
 
@@ -41,11 +41,11 @@ Next, we will run the test.ping command to ensure that the Salt Minion is connec
 ```
 salt '*' test.ping
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 We can use the cmd.run execution module to run a remote command on the Salt Minion. In this case, we're checking what version of python is running on the Salt Minion.
 
 ```
 salt minion* cmd.run 'python -V'
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>

--- a/lessons/lesson-30/stage2/guide.md
+++ b/lessons/lesson-30/stage2/guide.md
@@ -32,19 +32,19 @@ The Proxy Minion is now configured and is ready to start.
 ```
 salt-proxy --proxyid=vqfx1 -d
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 ( Note: it might take sometime for the key to be populated. Keep executing the below command every few seconds, until you see the "vqfx1" key listed. )
 ```
 salt-key -L
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 Let's accept the Salt Proxy Minion's public key using the command
 ```
 salt-key --accept="vqfx1" -y
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 Once this is done, the Salt Master will be able to communicate with the Salt Proxy Minion
 
@@ -53,6 +53,6 @@ Next, let's retrieve the device facts using the junos.facts execution module to 
 ```
 salt 'vqfx1' junos.facts
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 Now that the Salt Environment is setup, let's dive deeper into the world of Salt!

--- a/lessons/lesson-30/stage3/guide.md
+++ b/lessons/lesson-30/stage3/guide.md
@@ -13,7 +13,7 @@ The junos.cli execution module allows the Salt Master to run cli commands on the
 ```
 salt 'vqfx1' junos.cli 'show interfaces terse' format=xml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 The junos.rpc execution module runs RPC's on the Juniper device and returns the output on the terminal.
 In order to get the the RPC command equivalent for a CLI command , we use 'display xml rpc' after the pipe symbol ( | )
@@ -30,7 +30,7 @@ Let us now run the junos.rpc command. We can specify a destination file where th
 ```
 salt 'vqfx1' junos.rpc get-route-information /var/tmp/route.xml terse=True
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('salt1', this)">Run this snippet</button>
 
 To verify that the output was written to the '/var/tmp/route.xml', execute:
 

--- a/lessons/lesson-31/stage1/guide.md
+++ b/lessons/lesson-31/stage1/guide.md
@@ -20,7 +20,7 @@ Before we proceed, we need to move to the right directory. Terraform is ran in a
 ```
 cd /antidote/lessons/lesson-31/terraform/
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 
 __Terraform Init__
@@ -30,7 +30,7 @@ Terraform's first stage for any roll-out of resources starts with init and befor
 ```
 ls -la
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 What you can see are several Terraform resources which are configuration text files with the extension `.tf`. These configuration files make use of Terraform providers and in our case, these providers reside in the binary file `terraform-provider-junos-qfx`. This binary file contains an experimental and limited set of implementations focussed on the Juniper QFX switch. We'll cover the contents of the Terraform resource files in the next lesson.
 
@@ -41,7 +41,7 @@ Terraform needs to be initialized still, so let's go ahead and do that now. As y
 ```
 terraform init
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Terraform maintains state files for resource state. This is a source of truth that can inspected and manipulated through the Terraform application. Terraform from a virgin launch, doesn't have any state and by initializing Terraform, these things happen:
 
@@ -54,7 +54,7 @@ The eagle eyed amongst you might have checked the directory content after doing 
 ```bash
 ls -la
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 __Bonus material__
 
@@ -63,7 +63,7 @@ If you want to quickly see what's inside the new directory created by Terraform,
 ```
 tree .terraform
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Terraform is very feature rich and if you're interested in reading more, the documentation is excellent which can be found [here](https://www.terraform.io/docs/index.html).
 

--- a/lessons/lesson-31/stage2/guide.md
+++ b/lessons/lesson-31/stage2/guide.md
@@ -14,7 +14,7 @@ To keep things easy.
 ```
 cd /antidote/lessons/lesson-31/terraform
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 ## Planning
 
@@ -25,14 +25,14 @@ Let's go ahead and run Terraform plan and see what's going to happen.
 ```
 terraform plan
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 What you should see is two resources being described and in what order; an interface inet configuration followed by a BGP peer. There is an explicit dependency made in the file `bgp_peer_1.tf`.
 
 ```
 cat bgp_peer_1.tf
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Cool huh?
 
@@ -43,7 +43,7 @@ Here's an example of the `graphviz dot` output for this Terraform execution plan
 ```
 terraform graph -type=plan
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 You can feed the output of this operation to `dot` and generate graphics.
 

--- a/lessons/lesson-31/stage3/guide.md
+++ b/lessons/lesson-31/stage3/guide.md
@@ -16,14 +16,14 @@ First we need to make sure we're in the correct working directory.
 ```
 cd /antidote/lessons/lesson-31/terraform/
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Now let's apply the previously created execution plan.
 
 ```
 terraform apply -auto-approve
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 When this completes, not only are the resources created on Junos but also Terraform creates a state file which can be inspected really easily.
 
@@ -34,19 +34,19 @@ show interfaces em4
 show bgp summary
 ping 10.31.0.13 count 10
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 ```
 cat terraform.tfstate
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 At this point we can also check to make sure that the cache reflects the plan:
 
 ```
 terraform plan
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 You've just created some resources on Junos using Terraform! How cool is this? There are two view points here worth a brief discussion on (don't fear, it will be super brief so you can get back at it!). 
 
@@ -59,7 +59,7 @@ You can check the resources created by Terraform by checking the current content
 ```
 show configuration groups
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 Like container and cloud approaches to applications, the ideas is we can just destroy the resources when we don't need them, without having to figure out dependencies like we traditionally would.
 
@@ -72,14 +72,14 @@ This is a user exercise and you're next challenge is to change the IP address on
 ```
 vim bgp_peer_1.tf
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Once you've done this, run terraform plan again!
 
 ```
 terraform plan
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Here's an example of what you should be seeing.
 
@@ -106,7 +106,7 @@ Let's go ahead and apply the change.
 ```
 terraform apply -auto-approve
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 Now the BGP session remote peer address has been changed and you're free to check the configuration group configuration entry on `vqfx` to gain evidence of this wizardy.
 
@@ -115,7 +115,7 @@ Peaking under the hood, the Junos Terraform provider destroys the group by NETCO
 ```
 show configuration groups
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 __Idempotency__
 

--- a/lessons/lesson-31/stage4/guide.md
+++ b/lessons/lesson-31/stage4/guide.md
@@ -12,17 +12,17 @@ First we need to make sure we're in the correct working directory.
 ```
 cd /antidote/lessons/lesson-31/terraform/
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 ```
 show configuration groups
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 ```
 terraform destroy -auto-approve
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 What we did here was just remove the resources Terraform has cache data for. You might be thinking how you approach multiple customer data and multiple devices and the answer is through using directories. Each directory contains specific cache data and unless you've built your Terraform configurations to use global data, by design the data is isolated.
 

--- a/lessons/lesson-31/stage5/guide.md
+++ b/lessons/lesson-31/stage5/guide.md
@@ -8,7 +8,7 @@ Before we do any more, let's make sure we're in the correct working directory.
 ```
 cd /antidote/lessons/lesson-31/terraform/bonus/
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 __Implicit vs Explicit Graph Dependencies__
 
@@ -22,7 +22,7 @@ Let's go ahead and see if we can create an implicit dependency using variables!
 terraform init
 terraform plan
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 What you should see is a plan that looks like the following:
 
@@ -62,7 +62,7 @@ Notice that the VLAN resource is at the top? We can guarantee this order by form
 cat vlan_42_dt.tf
 cat access_port_dt.tf
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 You should see variables being used which refers to the resource name and the key within the resource like:
 
@@ -91,7 +91,7 @@ What happens if you don't want to destroy everything in a set of Terraform confi
 ```
 terraform destroy -h
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('terraform1', this)">Run this snippet</button>
 
 See the `-target` argument?
 

--- a/lessons/lesson-32/stage1/guide.md
+++ b/lessons/lesson-32/stage1/guide.md
@@ -18,7 +18,7 @@ device.open()
 device.get_snmp_information()
 quit()
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 As an example, one of the many potential findings within the STIG for Juniper network equipment stipulates that all [network devices must only allow read-only SNMP access](https://stigviewer.com/stig/infrastructure_router__juniper/2018-03-06/finding/V-3969). As we can see, `vqfx1` would be in violation of this rule.
 
@@ -28,14 +28,14 @@ Now of course, you're already thinking we can just run this check in a simple sc
 cd /antidote/lessons/lesson-32/stage1/
 cat napalm_verify_snmp.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 We've intentionally configured `vqfx1` ahead of time to have a read-write string, so that we see the violation when we run the napalm validate command with this test:
 
 ```
 napalm --user=antidote --password=antidotepassword --vendor=junos vqfx1 validate napalm_verify_snmp.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 There's a lot to go through in the resulting JSON output, but the important thing is the high-level key "complies" has a value of `false`.
 This means that the test we wrote to assert that the SNMP community string adheres to V-3969 is showing noncompliance on this device.
@@ -47,28 +47,28 @@ configure
 set snmp community antidote authorization read-only
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 We can re-execute this test now and see that the assertion passes:
 
 ```
 napalm --user=antidote --password=antidotepassword --vendor=junos vqfx1 validate napalm_verify_snmp.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 [Another finding stipulates](https://stigviewer.com/stig/infrastructure_router__juniper/2018-03-06/finding/V-31285) that all eBGP or iBGP peers must be authenticated. We've constructed another YAML file for testing this, using NAPALM's built-in functionality to allow regular expressions to match retrieved values:
 
 ```
 cat napalm_verify_bgp.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In this case, the regular expression `.+` is used to ensure that the authentication key used is **at least** one character. This means that, if there is no authentication key configured, this test would fail. As we've pre-configured this BGP configuration without authentication, we can see that it does:
 
 ```
 napalm --user=antidote --password=antidotepassword --vendor=junos vqfx1 validate napalm_verify_bgp.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 As with before, this is an easy fix with a quick re-configuration:
 
@@ -78,14 +78,14 @@ set protocols bgp group PEERS neighbor 10.12.0.12 authentication-key antidote
 set protocols bgp group PEERS neighbor 10.31.0.13 authentication-key antidote
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 Now, we should again see all tests pass:
 
 ```
 napalm --user=antidote --password=antidotepassword --vendor=junos vqfx1 validate napalm_verify_bgp.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 This lab has intentionally left a few things out:
 - It doesn't ensure compliance. It just detects noncompliance in an automated way. This is very valuable, but even more valuable is the ability to couple these tests with something like a Python script or Ansible playbook to perform the necessary compliance changes automatically when a violation is detected.

--- a/lessons/lesson-32/stage2/guide.md
+++ b/lessons/lesson-32/stage2/guide.md
@@ -16,7 +16,7 @@ Let's dive into this lab. As with the previous lab, `vqfx1` has been intentional
 ```
 show configuration snmp | display xml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 We've built a test file similar to what we saw in the introduction to JSNAPy, but this one captures both of the findings we'll explore in this lab. This is totally based on preference - JSNAPy allows you to place all tests in the same file, or split them up however you want.
 
@@ -24,7 +24,7 @@ We've built a test file similar to what we saw in the introduction to JSNAPy, bu
 cd /antidote/lessons/lesson-32/stage2/
 cat jsnapy_tests.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 The test `test_v-3969_snmp_readonly` uses the `get-config` RPC to retrieve the configuration from the device. Then, it uses the xpath expression `snmp/community` to narrow down in the configuration to the exact node we want to look at. Finally, it asserts in the test that the node `authorization` is exactly equal to `read-only`.
 
@@ -33,7 +33,7 @@ Since we saw in the previous snippet that this was not true, we can run these te
 ```
 jsnapy --snapcheck -f jsnapy_config.yaml -v
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Again, easy fix manually (though again, you should build some kind of automated remediation to findings like this - however, this will suffice for now).
 
@@ -42,14 +42,14 @@ configure
 set snmp community antidote authorization read-only
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 Running this again shows our SNMP test now passes:
 
 ```
 jsnapy --snapcheck -f jsnapy_config.yaml -v
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 However, a byproduct of also including our V-31285 test which asserts the BGP configuration uses authentication for all peers, makes our entire test suite fail, even though the SNMP read-only check is passing on its own.
 
@@ -58,21 +58,21 @@ Let's take a look at the BGP neighbor information:
 ```
 show bgp neighbor | display xml | no-more
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 One cool trick that most don't know about in Junos is the ability to use the expression `| display xml rpc` to display the name of the RPC call that would retrieve the same information:
 
 ```
 show bgp neighbor | display xml rpc
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 If we take another look at the JSNAPy test, we can see this is the RPC we're using in our second test:
 
 ```
 cat jsnapy_tests.yaml
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Another advantage of using JSNAPy is, due to the fact that it uses XPath to locate data in the XML hierarchy, we can make assertions on all child elements of a node, or a specific one. This means we can write one test to assert that any and all BGP peers are configured with authentication.
 
@@ -86,14 +86,14 @@ set protocols bgp group PEERS neighbor 10.12.0.12 authentication-key antidote
 set protocols bgp group PEERS neighbor 10.31.0.13 authentication-key antidote
 commit and-quit
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 Running our tests once more shows all passing, and we're now fully compliant with the two findings we've been looking at:
 
 ```
 jsnapy --snapcheck -f jsnapy_config.yaml -v
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 JSNAPy was designed from the beginning for multiple tests across multiple devices. You can maintain your tests in the way you want, either in separate files, or grouped according to functionality, other guidelines, etc. If we wanted to run the same tests across more than just this one `vqfx1` device, we would only need to add them to the inventory in the JSNAPy config file.
 

--- a/lessons/lesson-33/stage1/guide.md
+++ b/lessons/lesson-33/stage1/guide.md
@@ -17,14 +17,14 @@ dev = Device(host="vqfx1", user="antidote", password="antidotepassword")
 dev.open()
 print dev.facts
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 At the end you can see all the device `facts` printed but it is kind of difficult to read and see the structure of the data. To fix this we can use the pretty print module **(pprint)** to give the `facts` some structure and make them easier to read.
 <pre>
 from pprint import pprint
 pprint (dev.facts)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Now that looks a little better! The device `facts` are stored in a Python dictionary which are comprised of key/value pairs separated by a colon (:). Look at the output and find the key/value pairs for hostname & model. It should look like this:
 
@@ -36,21 +36,21 @@ In most cases you only want or need a couple of these facts and not the entire d
 <pre>
 print dev.facts['hostname']
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 `dev` represents your connection to the device, `facts` relates to the facts dictionary and `hostname` is the specific key of the facts dictionary that you want to display. Lets do this again for the `model` key.
 
 <pre>
 print dev.facts['model']
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 The last thing to do is to put multiple values on the same line separated by a unique character. This type of operation is very easy with Python. We will use the semicolon character as our separator.
 
 <pre>
 print dev.facts['hostname'] + ";" + dev.facts['model']
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Thats it....Easy Peasy Lemon squeezy!! :)
 

--- a/lessons/lesson-33/stage2/guide.md
+++ b/lessons/lesson-33/stage2/guide.md
@@ -16,7 +16,7 @@ First we need a list of device names or IP addresses that we want to retrieve in
 cd /antidote/lessons/lesson-33/stage2/
 more devices.yml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Pretty simple, right? New devices can be easily added without tinkering around in the script. Now lets start on the script. Start python, import the YAML module and import the Junos PyEz module.
 
@@ -25,7 +25,7 @@ python
 import yaml
 from jnpr.junos import Device
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Next we have to read in the YAML file with the device hostnames/IP addresses. First, open the `devices.yml` file as readonly and then use the YAML module to put it into a Python list, like so:
 
@@ -33,20 +33,20 @@ Next we have to read in the YAML file with the device hostnames/IP addresses. Fi
 deviceFile = open('devices.yml', 'r')
 deviceList = yaml.full_load(deviceFile)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Lets print the `deviceList` variable to ensure the devices.yml file has been processed correctly.
 <pre>
 print deviceList
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 It would be helpful to have a column header so you can easily know what each field value is. This can be done with a simple `print` statement.
 
 <pre>
 print("HOSTNAME;MODEL;SERIAL-NUMBER;JUNOS-VERSION")
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Now this is where the magic happens!  We are going to create a `for` loop so we can perform a series of actions on each device in the list (i.e. YAML file). The first thing we do is create the `dev` variable that includes the device hostname and login credentials. Next we `open` a NETCONF connection to the device so we can query the `facts`. 
 
@@ -60,7 +60,7 @@ for device in deviceList:
 	dev.close()
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the linux terminal on the right you can see the loop working, accessing each device and printing the facts. In the NRE Labs environment the serial number of the vQFX switches are the same but wont be the case in your production or lab environment.
 

--- a/lessons/lesson-34/stage1/guide.md
+++ b/lessons/lesson-34/stage1/guide.md
@@ -14,13 +14,13 @@ python
 from jnpr.junos import Device
 from lxml import etree
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 After that, we will create a new text file for the configuration to be saved. The file will be named **vqfx1-backup.txt** and will be in the home directory on the Linux system. 
 <pre>
 outfile = open("vqfx1-backup.txt","w")
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Next we create the `dev` variable that represents the device hostname and login credentials. Then we need to `open` a NETCONF connection to the device.
 
@@ -28,7 +28,7 @@ Next we create the `dev` variable that represents the device hostname and login 
 dev = Device(host="vqfx1", user="antidote", password="antidotepassword")
 dev.open()
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Then we will use the `rpc.get_config` function to pull the device configuration and store it in a variable called `config`. Next we `write` the configuration to the local file and finally `close` the local file.
 <pre>
@@ -36,7 +36,7 @@ config = dev.rpc.get_config(options={'format':'set'})
 outfile.write(etree.tostring(config))
 outfile.close()
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the Linux terminal you can see it making a connection with each device and saving the configuration. Wait until you see the `>>>`  prompt before running the next snippet. 
 
@@ -44,17 +44,17 @@ In order to verify the backed up configurations we will need to exit the Python 
 <pre>
 exit()
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Do a listing of the directory to see the **vqfx1-backup.txt** file with the current date and timestamp.  
 <pre>
 ls -l
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 If you would like to see the configuration backed up you can use the `cat` command to view the backed up configuration file.
 <pre>
 cat vqfx1-backup.txt
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 

--- a/lessons/lesson-34/stage2/guide.md
+++ b/lessons/lesson-34/stage2/guide.md
@@ -13,7 +13,7 @@ First we need a list of device names or IP addresses that we want to retrieve in
 cd /antidote/lessons/lesson-34/stage2/
 more devices.yml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 With this method new devices can be easily added without editing in the script.
 
@@ -24,20 +24,20 @@ import yaml
 from jnpr.junos import Device
 from lxml import etree
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button> 
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button> 
 
 Next we have to read in the YAML file with the device hostnames. First, open the file as readonly and then use the YAML module to put it into a Python list, like so:
 <pre>
 deviceFile = open('devices.yml', 'r')
 deviceList = yaml.full_load(deviceFile)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 2)">Run this snippet</button> 
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button> 
 
 To ensure the `devices.yml` file was processed correctly we can print the `deviceList` variable.
 <pre>
 print deviceList
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 We need to create a `for` loop so we can perform a series of actions on each device in the list (i.e. YAML file). The first thing we do is create the `dev` variable that represents the device hostname and login credentials. Then we need to `open` a NETCONF connection to the device.
 
@@ -54,7 +54,7 @@ for device in deviceList:
 	outfile.close()
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 In the Linux terminal you can see the loop making a connection with each device and saving the configuration. Wait until you see the `>>>`  prompt before running the next snippet. 
 
@@ -62,17 +62,17 @@ In order to verify the backed up configurations we will need to exit the Python 
 <pre>
 exit()
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 Lets do a directory listing looking for the backup files.
 <pre>
 ls -l
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
 View one of the backed up configuration files using the `cat` command. 
 <pre>
 cat vqfx1-backup.txt
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 

--- a/lessons/lesson-35/stage1/guide.md
+++ b/lessons/lesson-35/stage1/guide.md
@@ -18,7 +18,7 @@ Lets take a look at our sample configuration template that has already had the J
 cd /antidote/lessons/lesson-35/stage1
 more template.j2
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Jinja2 variables can be almost any combinations of numbers or lower case or upper case letters but in this example we will use all captial letters so they stand out better. The variables are surrounded by double curly brackets, for example **{{ HOSTNAME }}**. In the output look for the three template variables (**HOSTNAME, MGMT\_IP and DEFAULT\_GW**). Pay attention to these variable names because they will be set to specific values in the next section using YAML.
 
@@ -29,7 +29,7 @@ YAML is a human friendly data serialization standard but what does that mean? It
 cd /antidote/lessons/lesson-35/stage1
 more variables.yml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 The format of this file is called a dictionary which is a mapping of unique key and value pairs. The **Key** is on the left side of the colon (:) and **Value** is on the right side. So **HOSTNAME** is the key and **ex4300-3** is the value of that key.
 
@@ -39,7 +39,7 @@ Now lets get into python and see what it looks like and how it works. First we r
 python
 import yaml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we have to open the variables.yml file, read the file and then load the data into a variable called `my_vars`.
 <pre>
@@ -47,13 +47,13 @@ var_file = open('variables.yml')
 var_data = var_file.read()
 my_vars = yaml.full_load(var_data)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Alright, now lets ensure the data has been properly read and loaded by printing the `my_vars` variable.
 <pre>
 print my_vars
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 In the output you can see the upper case keys and their coresponding values, for example **'HOSTNAME': 'ex4300-3'**.
 
@@ -63,7 +63,7 @@ Now we will generate a configuration based on the device template and YAML data.
 <pre>
 from jinja2 import Template
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we have to open and read the device template that contains the Junos configuration with Jinja2 variables and store it a variable called `template`.
 
@@ -72,14 +72,14 @@ template_file = open('template.j2')
 template_data = template_file.read()
 template = Template(template_data)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Lastly we will render the template based on the data from the YAML file.
 
 <pre>
 print(template.render(my_vars))
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 You can see from the output on the linux terminal that all three variables have successfully been substituted with the values from the YAML configuration file. Go to the next section to see a more practical example.
 

--- a/lessons/lesson-35/stage2/guide.md
+++ b/lessons/lesson-35/stage2/guide.md
@@ -16,7 +16,7 @@ In this section we will use the same template file that we used in the previous 
 cd /antidote/lessons/lesson-35/stage2
 more template.j2
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 
 #### YAML Variables File 
@@ -26,7 +26,7 @@ In this section we will generate configurations for multiple devices. In order t
 cd /antidote/lessons/lesson-35/stage2
 more variables.yml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 You can see that variables.yml file contains three variables for three access switches that will we generate configurations for.
 
@@ -36,7 +36,7 @@ Now lets get into python and see what it looks like and how it works. First we r
 python
 import yaml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we have to open the variables.yml file, read the file and load the data into into a variable called `my_vars`.
 <pre>
@@ -44,13 +44,13 @@ var_file = open('variables.yml')
 var_data = var_file.read()
 my_vars = yaml.full_load(var_data)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Alright, now lets ensure the data has been properly read and loaded by printing the `my_vars` variable.
 <pre>
 print my_vars
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Template Generation
 Now we will generate a configuration based on the device template and YAML data. This is done using Jinja2 so we have to import the Jinja2 module.
@@ -58,7 +58,7 @@ Now we will generate a configuration based on the device template and YAML data.
 <pre>
 from jinja2 import Template
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we have to open and read the device template that contains the Junos configuration with Jinja2 variables and store it a variable called `template`.
 
@@ -67,7 +67,7 @@ template_file = open('template.j2')
 template_data = template_file.read()
 template = Template(template_data)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Lastly we will render the template based on the data from the YAML file. Since we are dealing with multiple devices we have to use a loop to process each device defined in the YAML file. The loop will run through the `my_vars` list processing each element one at a time, making the substitutions of the key/value pairs until there arent any elements left.
 
@@ -77,7 +77,7 @@ for device in my_vars:
 
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Scroll back on the linux terminal and you can see that the substitutions were performed for each of the three access switches listed in the YAML configuration file. 
 
@@ -91,25 +91,25 @@ for device in my_vars:
 
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Nothing was outputted to the screen because the data was written to the file. We will exit the Python interactive shell so we can look at the files.
 <pre>
 quit()
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Lets look at the files in the directory. Notice that the ex4300-x.conf files are now present.
 <pre>
 ls -l
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Lets look at one of the newly generate configuration files.
 <pre>
 cat ex4300-3.conf
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 11)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Things to try
 The session is complete but if you want to play around on your own, here are a couple of things to try.
@@ -121,6 +121,6 @@ Regenerating the configuration files can be done using the `build-configs.py` sc
 <pre>
 ./build-configs.py
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 12)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 

--- a/lessons/lesson-35/stage3/guide.md
+++ b/lessons/lesson-35/stage3/guide.md
@@ -18,7 +18,7 @@ In order to add the uplink ports we need to add values to the YAML file. We will
 cd /antidote/lessons/lesson-35/stage3
 head -12 variables.yml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 There are two uplinks, one that will connect to `distro1` and the other that will connect to `distro2`. For each connection you specify the **INTERFACE** and **DESCRIPTION** keys with their corresponding values.
 
@@ -28,7 +28,7 @@ In order to create the multiple uplink ports we will need to modify the Jinja2 t
 cd /antidote/lessons/lesson-35/stage3
 head -18 template.j2
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 See the `for` loop syntax **\{% for item in UPLINKS %\}**. When the loop is executed `item` will be set to `distro1` on the first pass and then be set to `distro2` on the second pass, each time printing the **INTERFACE** and **DESCRIPTION** values that are set.
 
@@ -39,7 +39,7 @@ Now lets get into python and see what it looks like and how it works. First we r
 python
 import yaml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we have to open the variables.yml file, read the file and load the data into into a variable called `my_vars`.
 <pre>
@@ -47,14 +47,14 @@ var_file = open('variables.yml')
 var_data = var_file.read()
 my_vars = yaml.full_load(var_data)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Alright, now lets ensure the data has been properly read and loaded by printing the my_vars variable. Since the data is somewhat complex we will using the pretty print (pprint) module to display the data in a structured way so its more readable.
 <pre>
 from pprint import pprint
 pprint(my_vars)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Template Generation
 Now we will generate a configuration based on the device template and YAML data. This is done using Jinja2 so we have to import the Jinja2 module.
@@ -62,7 +62,7 @@ Now we will generate a configuration based on the device template and YAML data.
 <pre>
 from jinja2 import Template
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we have to open and read the device template that contains the Junos configuration with Jinja2 variables and store it a variable called template.
 
@@ -71,7 +71,7 @@ template_file = open('template.j2')
 template_data = template_file.read()
 template = Template(template_data)
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Lastly we will render the template based on the data. Since we are dealing with multiple devices we have to use a loop to process each device defined in the YAML directionary.
 
@@ -82,7 +82,7 @@ for device in my_vars:
 
 quit()
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Scroll back on the linux terminal and you can see that the substitutions were performed for each of the three access switches listed in the YAML configuration file. 
 
@@ -97,6 +97,6 @@ Regenerating the configuration files can be done using the `build-configs.py` sc
 <pre>
 ./build-configs.py
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 

--- a/lessons/lesson-35/stage4/guide.md
+++ b/lessons/lesson-35/stage4/guide.md
@@ -12,13 +12,13 @@ First lets see what VLANs are already configured on the QFX switches, starting w
 <pre>
 show configuration vlans
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 0)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 and on vqfx2:
 <pre>
 show configuration vlans
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', 1)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', this)">Run this snippet</button>
 
 Notice the only VLAN configured is the default VLAN and a VLAN tag of 1.
 
@@ -29,7 +29,7 @@ We will use a YAML file to store the specific data for the VLANs we need to crea
 cd /antidote/lessons/lesson-35/stage4
 cat vlans.yml
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 2)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Device Template File
 In order to create multiple VLANs we will need a Jinja2 template with a `for` loop similar to what was done in the previous section. Lets look at the new template.
@@ -37,7 +37,7 @@ In order to create multiple VLANs we will need a Jinja2 template with a `for` lo
 cd /antidote/lessons/lesson-35/stage4
 cat template.j2
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 3)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 This template will automatically generate VLANs with names that:
 - Start with the letter **v**
@@ -64,7 +64,7 @@ template_data = template_file.read()
 template = Template(template_data)
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 4)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Next we need to `open` a new file, called `new-vlans.conf`, to store the generated configuration, `render` the Jinja2 template from data stored in the YAML file and then `close` the file. We will also `print` the generated configuration to the screen so we can see what it looks like.
 <pre>
@@ -74,7 +74,7 @@ outfile.close()
 print(template.render(my_vars))
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 5)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 #### Push Configuration to devices
 At this point the new VLANs have been created and written out to a file. Now we need to `open` and `load` the file that contains the list of devices that the template will be deployed to. The device list is another YAML fall called `devices.yml`.
@@ -83,7 +83,7 @@ deviceFile = open('devices.yml', 'r')
 deviceList = yaml.full_load(deviceFile)
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 6)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 We will use PyEz to connect to the QFX switches and push the configuration template so we have to load those modules.
 <pre>
@@ -91,7 +91,7 @@ from jnpr.junos import Device
 from jnpr.junos.utils.config import Config
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 7)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Since we are dealing with multiple device we need to create a `for` loop in order to connect to each device and push the configuration template. The `device` variable represents the device hostname and login credentials which are used to `open` a NETCONF connection to the device.
 
@@ -111,7 +111,7 @@ for device in deviceList:
      device.close()
 
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', 8)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux', this)">Run this snippet</button>
 
 Watch the output in the linux terminal. You will see the script looping through the QFX switches, pushing the configuration and printing the commit status messages. This may take a couple of minutes so wait until you see the `>>>` prompt.
 
@@ -120,11 +120,11 @@ Now lets check to see if the VLANs were successfully pushed, starting with vqfx1
 set cli screen-length 50
 show configuration vlans
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 9)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', this)">Run this snippet</button>
 
 and check vqfx2:
 <pre>
 set cli screen-length 50
 show configuration vlans
 </pre>
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx2', this)">Run this snippet</button>


### PR DESCRIPTION
https://github.com/nre-learning/antidote-web/pull/45 introduced the ability to use a consistent `this` keyword instead of trying to keep track of which 0-based index a given snippet is at on a page. Thanks, @jnpr-raylam!

So, we want to update all of the existing snippets in the curriculum. While the old index system is supported, the examples we want to put out there should use this, as it's simpler and will give us fewer headaches going forward.