### PR TITLE
Add a utility + VNC image

### DIFF
--- a/images/utility-vnc/Dockerfile
+++ b/images/utility-vnc/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+
+# Antidote user
+RUN mkdir -p /home/antidote
+RUN useradd antidote -p antidotepassword
+RUN chown antidote:antidote /home/antidote
+RUN chsh antidote --shell=/bin/bash
+RUN echo 'antidote:antidotepassword' | chpasswd
+RUN echo 'root:$(uuidgen)' | chpasswd
+
+# Adjust MOTD
+RUN rm -f /etc/update-motd.d/*
+RUN rm -f /etc/legal
+ADD motd.sh /etc/update-motd.d/00-antidote-motd
+
+# Disable root Login
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config
+RUN sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+# Disable su for everyone not in the wheel group (no one is in the wheel group)
+RUN echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
+#RUN apt-get update && apt-get install -y tigervnc-standalone-server tigervnc-common tini supervisor
+RUN apt-get update && apt-get install -y tigervnc-standalone-server tigervnc-common supervisor
+
+# tini isn't available for debian stretch (but comes in buster)
+ARG TINI_VERSION=v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
+RUN chmod +x /bin/tini
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+COPY start.sh /start.sh
+
+RUN apt-get update && apt-get install -y rsyslog
+
+RUN apt-get install -y sudo
+
+RUN adduser antidote sudo
+
+RUN apt-get install -y xterm
+
+EXPOSE 5900
+EXPOSE 22
+
+ENTRYPOINT ["/start.sh"]

--- a/images/utility-vnc/Dockerfile
+++ b/images/utility-vnc/Dockerfile
@@ -29,25 +29,20 @@ RUN echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
-#RUN apt-get update && apt-get install -y tigervnc-standalone-server tigervnc-common tini supervisor
-RUN apt-get update && apt-get install -y tigervnc-standalone-server tigervnc-common supervisor
+RUN apt-get update && apt-get install -y tigervnc-standalone-server tigervnc-common supervisor rsyslog sudo
 
 # tini isn't available for debian stretch (but comes in buster)
 ARG TINI_VERSION=v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
 RUN chmod +x /bin/tini
 
+RUN adduser antidote sudo
+
+RUN apt-get install -y fvwm xterm
+
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 COPY start.sh /start.sh
-
-RUN apt-get update && apt-get install -y rsyslog
-
-RUN apt-get install -y sudo
-
-RUN adduser antidote sudo
-
-RUN apt-get install -y xterm
 
 EXPOSE 5900
 EXPOSE 22

--- a/images/utility-vnc/motd.sh
+++ b/images/utility-vnc/motd.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+printf "\n"
+printf " ###############################################################\n"
+printf " #                     WELCOME TO ANTIDOTE                     #\n"            
+printf " #                                                             #\n"
+printf " # This is the 'utility' container. This is used to run Python #\n"
+printf " # scripts, workflows, tools, commands, etc - anything needed  #\n"
+printf " # to perform automation tasks on our network devices.         #\n"
+printf " #                                                             #\n"
+printf " # Documentation: https://antidoteproject.readthedocs.io       #\n"
+printf " ###############################################################\n"

--- a/images/utility-vnc/push.sh
+++ b/images/utility-vnc/push.sh
@@ -1,0 +1,2 @@
+docker build -t olberger/antidote-utility-vnc .
+docker push olberger/antidote-utility-vnc

--- a/images/utility-vnc/start.sh
+++ b/images/utility-vnc/start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+VNC_PASSWORD=${VNC_PASSWORD:-toto123}
+if [ -n "$VNC_PASSWORD" ]; then
+    # echo -n "$VNC_PASSWORD" > /.password1
+    # x11vnc -storepasswd $(cat /.password1) /.password2
+    # chmod 400 /.password*
+    # sed -i 's/^command=x11vnc.*/& -rfbauth \/.password2/' /etc/supervisor/conf.d/supervisord.conf
+    mkdir -p $HOME/.vnc/
+    echo "$VNC_PASSWORD" | /usr/bin/vncpasswd -f > $HOME/.vnc/passwd 
+    chmod 664 $HOME/.vnc/passwd
+
+    export VNC_PASSWORD=
+fi
+
+exec /bin/tini -- /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/images/utility-vnc/supervisord.conf
+++ b/images/utility-vnc/supervisord.conf
@@ -19,13 +19,20 @@ autorestart=true
 
 [program:vncserver]
 priority=10
-command=/usr/bin/Xtigervnc :0 -desktop "4f63fb08aeaa:1 (root)" -auth /root/.Xauthority -geometry 1900x1200 -depth 24 -rfbwait 30000 -rfbport 5900 -pn -SecurityTypes None
+command=/usr/bin/Xtigervnc :0 -desktop "4f63fb08aeaa:1 (root)" -auth /root/.Xauthority -geometry 800x600 -depth 24 -rfbwait 30000 -rfbport 5900 -pn -SecurityTypes None
 directory=/root
 stopsignal=KILL
 numprocs=1
 
-[program:xterm]
+[program:twm]
 priority=15
+directory=/root
+numprocs=1
+command=/usr/bin/fvwm
+environment=DISPLAY=":0"
+
+[program:xterm]
+priority=20
 directory=/root
 command=/usr/bin/xterm
 environment=DISPLAY=":0"

--- a/images/utility-vnc/supervisord.conf
+++ b/images/utility-vnc/supervisord.conf
@@ -1,0 +1,31 @@
+
+[supervisord]
+redirect_stderr=true
+stopsignal=QUIT
+autorestart=true
+directory=/root
+
+[program:rsyslog]
+command=/usr/sbin/rsyslogd -n
+numprocs=1
+autostart=true
+autorestart=true
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+numprocs=1
+autostart=true
+autorestart=true
+
+[program:vncserver]
+priority=10
+command=/usr/bin/Xtigervnc :0 -desktop "4f63fb08aeaa:1 (root)" -auth /root/.Xauthority -geometry 1900x1200 -depth 24 -rfbwait 30000 -rfbport 5900 -pn -SecurityTypes None
+directory=/root
+stopsignal=KILL
+numprocs=1
+
+[program:xterm]
+priority=15
+directory=/root
+command=/usr/bin/xterm
+environment=DISPLAY=":0"

--- a/lessons/lesson-99/stage1/guide.md
+++ b/lessons/lesson-99/stage1/guide.md
@@ -1,0 +1,87 @@
+# Linux Basics
+## Part 1 - Using the Bash Shell
+
+Welcome to "Linux Basics". While it's fun to talk about complex config management tools like Ansible, or get into scripting with Python, there's a more fundamental skill that underlies all of these. Knowing your way around a Linux system is becoming more than just a good idea, it's becoming table stakes if you want to get **anything** done in network automation or reliability engineering, and soon, it will be a given for all of networking.
+
+So, if you want to future-proof not only your network automation skills but also your networking skills as a whole, you've come to the right place. While a comprehensive overview of Linux is best saved for the massive amount of learning materials available on the subject, this lesson will focus on the really important aspects of knowing your way around a Linux system, especially as it pertains to being able to use Linux on your journey to Network Reliability Engineering.
+
+In this part of the lesson, we'll learn about Bash, which is an incredibly popular shell, present on nearly every *nix system. Think of it as the Cisco IOS CLI of Linux - it really is that pervasive. If you've ever looked at the command-line of a linux system, it was likely Bash that you saw.
+
+Let's learn a few important commands. We have a `linux1` system spun up in the terminal to the right, and the first thing we should do is get familiar with our filesystem. First, the `pwd` command tells us which directory we're in right now:
+
+```
+pwd
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+This is our "home" directory - the directory we start in by default when logged in as this user. Let's create a new directory called `mydirectory` by using the `mkdir` command:
+
+```
+mkdir newdirectory
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+No matter which directory you're currently in, you'll periodically want to know what it contains. For instance, we're still in our home directory, so we can use `ls` with a few flags to list all the files in this directory.
+
+```
+ls -lha
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+You may notice the flags `l`, `h`, and `a` are used here. These are optional, but a very common addition to `ls` because they do a few useful things for us:
+
+- `l` - output in list view in long format, instead of the usual "paragraph-style" view
+- `h` - provide human-readable values for filesize. E.g. instead of `6158` (which is bytes), we'll see `6.1K`)
+- `a` - show all files, including those that begin with a dot (`.`)
+
+Many systems alias this command to `ll` so you don't have to type out all the flags. Ours doesn't, but we can add an alias for it ourselves:
+
+```
+alias ll="ls -lha"
+ll
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+Note that by default, `ls -lha` (or our new alias `ll`) assumes you want to list the files (and directories) in the directory you're currently in, but we can provide a directory after the command to list the files in that location (assuming we have permissions to do so):
+
+```
+ll /
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+This command listed all the files in the directory `/`, which is known as the "root directory". This is the highest point in the directory structure - there's nothing above this. All of the files and directories you see in this output
+
+While we were able to list the contents of the root directory, our present working directory is still our home directory. We've been camping out in the home directory for a while - let's change to the new directory we created earlier:
+
+```
+cd newdirectory/
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+This is an empty directory (hint: try running `ll` here) so let's create a file. The `touch` command creates a new, empty file with the name you specify:
+
+```
+touch newfile.txt
+ll
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+Let's take a closer look at the output of `ll`. We can see the file we created, but we see three entries, instead of just one.
+
+The other two entries are present in nearly every directory. `.` is a shortcut for the current directory, and `..` is a shortcut for the parent directory.
+
+```
+antidote@linux1:~/newdirectory$ ll
+total 0
+drwxrwxr-x. 2 antidote antidote 25 Oct  8 09:08 .                      <---- Current Directory
+drwxr-xr-x. 1 antidote antidote 40 Oct  8 09:08 ..                     <---- Parent Directory
+-rw-rw-r--. 1 antidote antidote  0 Oct  8 09:08 newfile.txt
+```
+
+The latter, `..`, is super useful for being able to just "go up a directory", without having to use the absolute path we saw before (remember the output of `pwd`?). Every directory except the root directory has a parent, so we can use the shortcut `..` as an argument to `cd` to return to the home directory, as well as the parent of any other directory we may find ourselves in:
+
+```
+cd ..
+ll
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>

--- a/lessons/lesson-99/syringe.yaml
+++ b/lessons/lesson-99/syringe.yaml
@@ -1,0 +1,19 @@
+---
+lessonName: Debian X11 with VNC
+lessonId: 99
+category: fundamentals
+tier: prod
+tags:
+- linux
+- bash
+description: Being able to work with Linux and the Bash shell is becoming an increasingly important skill in the world of Network Reliability Engineering. In this lesson, we'll cover the basics of a Linux-based system, and get you acquainted with the Bash shell.
+slug: Linux
+
+utilities:
+- name: linux1
+  image: olberger/antidote-utility-vnc
+  ports: [22, 5900]
+
+stages:
+  - id: 1
+    description: Using the Bash Shell


### PR DESCRIPTION
This image is an attempt at providing a base image that could be used over VNC (and SSH).

This aims at being able to launch VNC connections to the endpoints once https://github.com/nre-learning/antidote-web/issues/65 is implemented.

It remains to be polished, in order to allow overloading it, in an easy way that allows installation of any X application that will use the XVnc display, and of course all the UX work for making everything well integrated in the Guacamole VNC display.