### PR TITLE
Removing tags from curriculum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added a lesson on BASH [Commit #1fe7b94](https://github.com/nre-learning/nrelabs-curriculum/commit/1fe7b94454e880b1a468b1d1742d2911139359ab)
 - Remove platform images from curriculum [#245](https://github.com/nre-learning/nrelabs-curriculum/pull/245)
 - Modified images to support a standard build process [#247](https://github.com/nre-learning/nrelabs-curriculum/pull/247)
+- Removing tags from curriculum [#248](https://github.com/nre-learning/nrelabs-curriculum/pull/248)
 
 ## v0.3.2 - April 19, 2019
 

--- a/lessons/fundamentals/lesson-1-demo/lesson.meta.yaml
+++ b/lessons/fundamentals/lesson-1-demo/lesson.meta.yaml
@@ -26,7 +26,7 @@ endpoints:
     type: http
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: python
   presentations:
   - name: cli
@@ -34,7 +34,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -42,7 +42,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/vqfx:snap3
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/fundamentals/lesson-1-demo/lesson.meta.yaml
+++ b/lessons/fundamentals/lesson-1-demo/lesson.meta.yaml
@@ -26,7 +26,7 @@ endpoints:
     type: http
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: python
   presentations:
   - name: cli
@@ -34,7 +34,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -42,7 +42,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap3
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/fundamentals/lesson-19-restapis/lesson.meta.yaml
+++ b/lessons/fundamentals/lesson-19-restapis/lesson.meta.yaml
@@ -26,7 +26,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -35,7 +35,7 @@ endpoints:
   additionalPorts: [8080]
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -44,7 +44,7 @@ endpoints:
   additionalPorts: [8080]
 
 - name: vqfx3
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap3
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/fundamentals/lesson-19-restapis/lesson.meta.yaml
+++ b/lessons/fundamentals/lesson-19-restapis/lesson.meta.yaml
@@ -26,7 +26,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -35,7 +35,7 @@ endpoints:
   additionalPorts: [8080]
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -44,7 +44,7 @@ endpoints:
   additionalPorts: [8080]
 
 - name: vqfx3
-  image: antidotelabs/vqfx:snap3
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-12-jsnapy/lesson.meta.yaml
+++ b/lessons/tools/lesson-12-jsnapy/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -33,7 +33,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -41,7 +41,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/vqfx:snap3
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-12-jsnapy/lesson.meta.yaml
+++ b/lessons/tools/lesson-12-jsnapy/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -33,7 +33,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -41,7 +41,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap3
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-13-napalm/lesson.meta.yaml
+++ b/lessons/tools/lesson-13-napalm/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-13-napalm/lesson.meta.yaml
+++ b/lessons/tools/lesson-13-napalm/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-15-stackstorm/lesson.meta.yaml
+++ b/lessons/tools/lesson-15-stackstorm/lesson.meta.yaml
@@ -26,7 +26,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -34,7 +34,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -42,7 +42,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/vqfx:snap3
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-15-stackstorm/lesson.meta.yaml
+++ b/lessons/tools/lesson-15-stackstorm/lesson.meta.yaml
@@ -26,7 +26,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -34,7 +34,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -42,7 +42,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap3
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-18-todd/lesson.meta.yaml
+++ b/lessons/tools/lesson-18-todd/lesson.meta.yaml
@@ -27,7 +27,7 @@ endpoints:
     type: http
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-18-todd/lesson.meta.yaml
+++ b/lessons/tools/lesson-18-todd/lesson.meta.yaml
@@ -27,7 +27,7 @@ endpoints:
     type: http
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-24-pyez/lesson.meta.yaml
+++ b/lessons/tools/lesson-24-pyez/lesson.meta.yaml
@@ -19,7 +19,7 @@ collection: 1
 endpoints:
 
 - name: vqfx
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-24-pyez/lesson.meta.yaml
+++ b/lessons/tools/lesson-24-pyez/lesson.meta.yaml
@@ -19,7 +19,7 @@ collection: 1
 endpoints:
 
 - name: vqfx
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-25-junosjet/lesson.meta.yaml
+++ b/lessons/tools/lesson-25-junosjet/lesson.meta.yaml
@@ -17,7 +17,7 @@ endpoints:
     type: ssh
 
 - name: vqfx
-  image: antidotelabs/vqfx-full:18.1R1.9
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-26-openconfig/lesson.meta.yaml
+++ b/lessons/tools/lesson-26-openconfig/lesson.meta.yaml
@@ -16,7 +16,7 @@ endpoints:
     type: ssh
 
 - name: vqfx
-  image: antidotelabs/vqfx-full:18.1R1.9
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-29-robot/lesson.meta.yaml
+++ b/lessons/tools/lesson-29-robot/lesson.meta.yaml
@@ -21,7 +21,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-29-robot/lesson.meta.yaml
+++ b/lessons/tools/lesson-29-robot/lesson.meta.yaml
@@ -21,7 +21,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-30-salt/lesson.meta.yaml
+++ b/lessons/tools/lesson-30-salt/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-30-salt/lesson.meta.yaml
+++ b/lessons/tools/lesson-30-salt/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-31-terraform/lesson.meta.yaml
+++ b/lessons/tools/lesson-31-terraform/lesson.meta.yaml
@@ -20,7 +20,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -28,7 +28,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -36,7 +36,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/vqfx:snap3
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/tools/lesson-31-terraform/lesson.meta.yaml
+++ b/lessons/tools/lesson-31-terraform/lesson.meta.yaml
@@ -20,7 +20,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -28,7 +28,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -36,7 +36,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap3
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-21-tshoot-ipphone/lesson.meta.yaml
+++ b/lessons/workflows/lesson-21-tshoot-ipphone/lesson.meta.yaml
@@ -29,7 +29,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -37,7 +37,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -45,7 +45,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap3
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-21-tshoot-ipphone/lesson.meta.yaml
+++ b/lessons/workflows/lesson-21-tshoot-ipphone/lesson.meta.yaml
@@ -29,7 +29,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -37,7 +37,7 @@ endpoints:
     type: ssh
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -45,7 +45,7 @@ endpoints:
     type: ssh
 
 - name: vqfx3
-  image: antidotelabs/vqfx:snap3
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-32-stigcompliance/lesson.meta.yaml
+++ b/lessons/workflows/lesson-32-stigcompliance/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-32-stigcompliance/lesson.meta.yaml
+++ b/lessons/workflows/lesson-32-stigcompliance/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-33-quickdeviceinventory/lesson.meta.yaml
+++ b/lessons/workflows/lesson-33-quickdeviceinventory/lesson.meta.yaml
@@ -24,7 +24,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -33,7 +33,7 @@ endpoints:
   additionalPorts: [830]
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-33-quickdeviceinventory/lesson.meta.yaml
+++ b/lessons/workflows/lesson-33-quickdeviceinventory/lesson.meta.yaml
@@ -24,7 +24,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -33,7 +33,7 @@ endpoints:
   additionalPorts: [830]
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-34-configbackup/lesson.meta.yaml
+++ b/lessons/workflows/lesson-34-configbackup/lesson.meta.yaml
@@ -24,7 +24,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -33,7 +33,7 @@ endpoints:
   additionalPorts: [830]
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-34-configbackup/lesson.meta.yaml
+++ b/lessons/workflows/lesson-34-configbackup/lesson.meta.yaml
@@ -24,7 +24,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -33,7 +33,7 @@ endpoints:
   additionalPorts: [830]
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-35-devicespecifictemplate/lesson.meta.yaml
+++ b/lessons/workflows/lesson-35-devicespecifictemplate/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap1
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -34,7 +34,7 @@ endpoints:
   additionalPorts: [830]
 
 - name: vqfx2
-  image: antidotelabs/container-vqfx
+  image: antidotelabs/vqfx-snap2
   configurationType: napalm-junos
   presentations:
   - name: cli

--- a/lessons/workflows/lesson-35-devicespecifictemplate/lesson.meta.yaml
+++ b/lessons/workflows/lesson-35-devicespecifictemplate/lesson.meta.yaml
@@ -25,7 +25,7 @@ endpoints:
     type: ssh
 
 - name: vqfx1
-  image: antidotelabs/vqfx:snap1
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli
@@ -34,7 +34,7 @@ endpoints:
   additionalPorts: [830]
 
 - name: vqfx2
-  image: antidotelabs/vqfx:snap2
+  image: antidotelabs/container-vqfx
   configurationType: napalm-junos
   presentations:
   - name: cli


### PR DESCRIPTION
This PR removes all tags from lesson definitions to be compatible with Syringe changes introduced in https://github.com/nre-learning/syringe/pull/123.

To minimize the impact of this change, we have pushed a new tag for the existing images (i.e. `antidotelabs/vqfx:snap1`) at the exact same image ID, but to an image name that doesn't rely on tags for differentiation. So, instead of:

- `antidotelabs/vqfx:snap1`
- `antidotelabs/vqfx:snap2`
- `antidotelabs/vqfx:snap3`

We have:

- `antidotelabs/vqfx-snap1`
- `antidotelabs/vqfx-snap2`
- `antidotelabs/vqfx-snap3`

These images are cryptographically identical to their tagged counterpart, but without the tag, we can now inject the appropriate version at the Syringe level per the new behavior. Both `latest` and `v0.4.0` versions of these images have been identically pushed, so that both production and PTR/selfmedicate can get the images they need.

As a result, this PR changes the lesson files to point to the correct image. **NOTE** that this is a temporary measure to get the existing curriculum images compatible with the new format. Enhancements to these images to overcome the mac address issue requiring this snapshotting trick are still on the radar.