### PR TITLE
Promoting initial batch of collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove platform images from curriculum [#245](https://github.com/nre-learning/nrelabs-curriculum/pull/245)
 - Modified images to support a standard build process [#247](https://github.com/nre-learning/nrelabs-curriculum/pull/247)
 - Removing tags from curriculum [#248](https://github.com/nre-learning/nrelabs-curriculum/pull/248)
+- Promoting initial batch of collections [#252](https://github.com/nre-learning/nrelabs-curriculum/pull/252)
 
 ## v0.3.2 - April 19, 2019
 

--- a/collections/ntc/collection.meta.yaml
+++ b/collections/ntc/collection.meta.yaml
@@ -12,4 +12,4 @@ briefDescription: Network To Code is leading the way in empowering the network e
 longDescription: |
   Network to Code, THE Network Automation Company, is a network automation solution provider helping clients around the world reduce manual inefficiencies and operations costs while helping IT teams deliver services faster resulting in quicker time to market, faster recognition of revenue, and increased customer satisfaction. It is our mission to change the way networks are managed, consumed, and operated on a day to day basis. Simply put, Network to Code bridges the gap between DevOps and Network Engineering/Operations. This is accomplished by providing services using off the shelf open source software (OSS) as well as integrating to existing manufacturer tools and technologies.
 type: consultancy
-tier: ptr
+tier: prod

--- a/collections/packetpushers/collection.meta.yaml
+++ b/collections/packetpushers/collection.meta.yaml
@@ -3,7 +3,7 @@ id: 9
 title: Packet Pushers
 image: https://raw.githubusercontent.com/nre-learning/nrelabs-curriculum/master/collections/packetpushers/pp.jpg
 website: https://packetpushers.net/
-contactEmail: "packetpushers@gmail.com"
+contactEmail: "operations@packetpushers.net"
 
 # Why should users view your collection?
 briefDescription: |

--- a/collections/packetpushers/collection.meta.yaml
+++ b/collections/packetpushers/collection.meta.yaml
@@ -10,6 +10,10 @@ briefDescription: |
     A podcast about networking & infrastructure engineering by IT architects. Deeply technical & unabashedly nerdy.
 # Why should users continue and view your lessons?
 longDescription: |
-    The Packet Pushers are awesome-sauce, full stop.
+    Packet Pushers is a community of IT practitioners & vendors who write, podcast, and help each other as industry professionals. The community is built primarily around our podcast network. We have several shows, seen in the top bar of this site. Packet Pushers covers networking as well as data center design, virtualization, and general technology trends.
+
+    The key for us is to make the content focused, practical, and deep, while at the same time having a bit of fun.
+
+    Packet Pushers is a full-time business supported by sponsorships from IT vendors. All sponsored content is clearly marked and still technical. We have vendors bring on technical folks and engineers to discuss their products at a meaningful level. We insist that our vendors offer value to our audience even while performing acts of marketing.
 type: community
-tier: ptr
+tier: prod

--- a/collections/twinbridges/collection.meta.yaml
+++ b/collections/twinbridges/collection.meta.yaml
@@ -1,0 +1,14 @@
+---
+id: 11
+title: Twin Bridges Technology
+image: https://pynet.twb-tech.com/static/img/python_logo.png
+website: https://pynet.twb-tech.com/
+
+# Why should users view your collection?
+briefDescription: Twin Bridges Technology is a small business specializing in network automation training.
+
+# Why should users continue and view your lessons?
+longDescription: |
+  Twin Bridges Technology is a small business specializing in network automation training.
+type: consultancy
+tier: prod

--- a/collections/twinbridges/collection.meta.yaml
+++ b/collections/twinbridges/collection.meta.yaml
@@ -5,10 +5,10 @@ image: https://pynet.twb-tech.com/static/img/python_logo.png
 website: https://pynet.twb-tech.com/
 
 # Why should users view your collection?
-briefDescription: Twin Bridges Technology is a small business specializing in network automation training.
+briefDescription: Twin Bridges Technology is a business specializing in network automation training.
 
 # Why should users continue and view your lessons?
 longDescription: |
-  Twin Bridges Technology is a small business specializing in network automation training.
+  Twin Bridges Technology is a network automation training company that features courses on Python Network Automation, Ansible, and Nornir. We run a popular Python for Network Engineers training course and created the Python-Netmiko library. We also maintain the NAPALM project and have made contributions to Nornir.
 type: consultancy
 tier: prod


### PR DESCRIPTION
Most of the collections currently in place are there as a PoC. We've talked to a lot of companies about getting involve with NRE Labs, so we create their company as a collection to show them what it might look like.

Since we're nearing the next release, I thought it valuable to promote a small portion of them to `prod` status so that they'll show in the UI when we move to the next release in the next few days.

Collections were initially thought of as a way to organize content, but it also serves as a useful way to link to external resources for "next steps". Naturally, Network to Code and Twin Bridges come to mind, as they specialize in network automation training. So, I included them in this batch as well. Packet Pushers, while they don't specialize in it like the other two companies, also have a ton of useful content for not just automation and networking in general.

If any of these companies wish to contribute lessons in the future, they're obviously welcome to do so, and this provides a home for that in the future. In the meantime, I think doing this is still useful to provide links for users to go somewhere once they're done with the lessons here. I plan on following this up with an `antidote-web` change to make this more obvious, as well.