### PR TITLE
Final Fixes for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Modified images to support a standard build process [#247](https://github.com/nre-learning/nrelabs-curriculum/pull/247)
 - Removing tags from curriculum [#248](https://github.com/nre-learning/nrelabs-curriculum/pull/248)
 - Promoting initial batch of collections [#252](https://github.com/nre-learning/nrelabs-curriculum/pull/252)
+- Final round of fixes for v1.0.0 based on feedback [#254](https://github.com/nre-learning/nrelabs-curriculum/pull/254)
 
 ## v0.3.2 - April 19, 2019
 

--- a/images/utility/Dockerfile
+++ b/images/utility/Dockerfile
@@ -32,5 +32,11 @@ RUN echo "export VISIBLE=now" >> /etc/profile
 ADD requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
+# Temporary measure to get the latest yaml fix
+RUN git clone https://github.com/Juniper/jsnapy.git /tmp/jsnapy \
+    && cd /tmp/jsnapy \
+    && git checkout dd0dbb12e47ec5183e9e2ac9cd99195c861c925e \
+    && python setup.py install
+
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/images/utility/push.sh
+++ b/images/utility/push.sh
@@ -1,2 +1,0 @@
-docker build -t antidotelabs/utility .
-docker push antidotelabs/utility

--- a/images/utility/requirements.txt
+++ b/images/utility/requirements.txt
@@ -1,11 +1,11 @@
+# https://github.com/paramiko/paramiko/issues/1369
+# (I think this is fixed now, so commenting this out. I ran into issues with this restriction on)
+# cryptography==2.4.2
 napalm
 netmiko
 jsnapy
-junos-eznc
 robotframework
 jinja2
 paho-mqtt
 grpcio
 grpcio-tools
-# https://github.com/paramiko/paramiko/issues/1369
-cryptography==2.4.2

--- a/lessons/fundamentals/lesson-14-yaml/stage2/guide.md
+++ b/lessons/fundamentals/lesson-14-yaml/stage2/guide.md
@@ -51,10 +51,11 @@ yamlDict['snmpcommunity']
 
 YAML and Python are quite liberal with the types that can be stored in a dictionary. We have a second YAML file that has a list (Python's version of an array), a string, and an integer, all stored as different values in the same dictionary:
 
-```
+<pre>
 yamlFile = open('complexdict.yaml', 'r')
 yamlDict = yaml.load(yamlFile)
 for key, value in yamlDict.items():
     print("The key %s is of type %s and its value %s is of type %s" % (key, type(key), value, type(value)))
-```
+
+</pre>
 <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>

--- a/lessons/fundamentals/lesson-17-git/stage1/guide.md
+++ b/lessons/fundamentals/lesson-17-git/stage1/guide.md
@@ -23,6 +23,16 @@ git init
 ```
 <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
+Before we go further, we should tell Git some information about us. At a minimum, in order to make commits, we need to provide a username and an email address:
+
+```
+git config --global user.email "jane@labs.networkreliability.engineering"
+git config --global user.name "Jane Doe"
+```
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
+
+The `--global` flag sets this in your Git configuration for the entire machine. You can omit this flag to only set it for this repository. This information is used to identify who has made changes to the files in the repository.
+
 A Git repository is nothing without some files to manage. Let's create a text file and add some text to it:
 
 ```

--- a/lessons/tools/lesson-13-napalm/stage1/notebook.ipynb
+++ b/lessons/tools/lesson-13-napalm/stage1/notebook.ipynb
@@ -7,8 +7,7 @@
     "# Multi-Vendor Network Automation with NAPALM\n",
     "\n",
     "## Part 1 - Get Device Facts\n",
-    "\n",
-    "> This lesson uses Jupyter notebooks to provide a guided experience with in-line, executable and editable code snippets. Read <a target=\"_blank\" href=\"/jupyterlessonguides.html\">here</a> for more details on how to interact with these."
+    "\n"
    ]
   },
   {

--- a/lessons/tools/lesson-13-napalm/stage2/notebook.ipynb
+++ b/lessons/tools/lesson-13-napalm/stage2/notebook.ipynb
@@ -7,8 +7,7 @@
     "# Multi-Vendor Network Automation with NAPALM\n",
     "\n",
     "## Part 2 - NAPALM's Getter Functions\n",
-    "\n",
-    "> This lesson uses Jupyter notebooks to provide a guided experience with in-line, executable and editable code snippets. Read <a target=\"_blank\" href=\"/jupyterlessonguides.html\">here</a> for more details on how to interact with these."
+    "\n"
    ]
   },
   {

--- a/lessons/tools/lesson-13-napalm/stage4/notebook.ipynb
+++ b/lessons/tools/lesson-13-napalm/stage4/notebook.ipynb
@@ -7,8 +7,7 @@
     "# Multi-Vendor Network Automation with NAPALM\n",
     "\n",
     "## Part 4 - Make Configuration Changes with NAPALM\n",
-    "\n",
-    "> This lesson uses Jupyter notebooks to provide a guided experience with in-line, executable and editable code snippets. Read <a target=\"_blank\" href=\"/jupyterlessonguides.html\">here</a> for more details on how to interact with these."
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
No major changes - just minor fixes that were raised in testing, and are easy and low-impact to fix.

# Fixes

- Installing correct version of python deps in utility image
- Removed section at the top of NAPALM jupyter notebooks that point to erroneous link. This link is provided, correctly, as part of the platform now, so this whole section is not needed.
- Added steps in Git lesson to add identity, so the commit works.
- Installing jsnapy manually by commit ID in utility image, to get the YAML fix.
- Adjust guide for stage 2 of the YAML lesson so that the last snippet uses `<pre>` tags, to fix the need to hit enter to get the code to execute.