### PR TITLE
Disable caching for image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## In development
 
 - Added Cumulus PTR demo [#253](https://github.com/nre-learning/nrelabs-curriculum/pull/253)
-- Updated collection in BASH lesson file to 9 (PacketPushers)
+- Updated collection in BASH lesson file to 9 (PacketPushers) [#258](https://github.com/nre-learning/nrelabs-curriculum/pull/258)
+- Disable caching for all image builds [#260](https://github.com/nre-learning/nrelabs-curriculum/pull/260)
 
 ## v1.0.0 - August 08, 2019
 

--- a/images/asterisk/Makefile
+++ b/images/asterisk/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/asterisk:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/asterisk:$(TARGET_VERSION) .
 	docker push antidotelabs/asterisk:$(TARGET_VERSION)

--- a/images/container-vqfx/build.sh
+++ b/images/container-vqfx/build.sh
@@ -14,5 +14,5 @@ for image in *.img; do
   version=$TARGET_VERSION
 
   echo "Building container $target:$version ... "
-  docker build -f Dockerfile.junos --build-arg image=$image --build-arg ocpkg=$ocpkg -t $target:$version .
+  docker build --pull --no-cache -f Dockerfile.junos --build-arg image=$image --build-arg ocpkg=$ocpkg -t $target:$version .
 done

--- a/images/container-vqfx/build.sh
+++ b/images/container-vqfx/build.sh
@@ -3,7 +3,7 @@
 target=antidotelabs/container-vqfx
 ocpkg=$(ls junos-openconfig-*.tgz)
 
-docker build -f src/Dockerfile -t container-vqfx src
+docker build --pull --no-cache -f src/Dockerfile -t container-vqfx src
 
 for image in *.img; do
 
@@ -14,5 +14,5 @@ for image in *.img; do
   version=$TARGET_VERSION
 
   echo "Building container $target:$version ... "
-  docker build --pull --no-cache -f Dockerfile.junos --build-arg image=$image --build-arg ocpkg=$ocpkg -t $target:$version .
+  docker build --no-cache -f Dockerfile.junos --build-arg image=$image --build-arg ocpkg=$ocpkg -t $target:$version .
 done

--- a/images/cvx/Makefile
+++ b/images/cvx/Makefile
@@ -6,6 +6,6 @@ all: docker
 
 docker:
 	gsutil cp "gs://nrelabs-curriculum-base-images/cvx/cvx.qcow2" "./cvx.qcow2"
-	docker build -t antidotelabs/cvx:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/cvx:$(TARGET_VERSION) .
 	docker push antidotelabs/cvx:$(TARGET_VERSION)
 

--- a/images/netbox/Makefile
+++ b/images/netbox/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/netbox:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/netbox:$(TARGET_VERSION) .
 	docker push antidotelabs/netbox:$(TARGET_VERSION)

--- a/images/pjsua-lindsey/Makefile
+++ b/images/pjsua-lindsey/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/pjsua-lindsey:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/pjsua-lindsey:$(TARGET_VERSION) .
 	docker push antidotelabs/pjsua-lindsey:$(TARGET_VERSION)

--- a/images/salt/Makefile
+++ b/images/salt/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/salt:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/salt:$(TARGET_VERSION) .
 	docker push antidotelabs/salt:$(TARGET_VERSION)

--- a/images/selfservice-flask-app/Makefile
+++ b/images/selfservice-flask-app/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/selfservice-flask-app:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/selfservice-flask-app:$(TARGET_VERSION) .
 	docker push antidotelabs/selfservice-flask-app:$(TARGET_VERSION)

--- a/images/st2/Makefile
+++ b/images/st2/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/stackstorm:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/stackstorm:$(TARGET_VERSION) .
 	docker push antidotelabs/stackstorm:$(TARGET_VERSION)

--- a/images/terraform/Makefile
+++ b/images/terraform/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/terraform:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/terraform:$(TARGET_VERSION) .
 	docker push antidotelabs/terraform:$(TARGET_VERSION)

--- a/images/utility/Makefile
+++ b/images/utility/Makefile
@@ -5,5 +5,5 @@ TARGET_VERSION ?= latest
 all: docker
 
 docker:
-	docker build -t antidotelabs/utility:$(TARGET_VERSION) .
+	docker build --pull --no-cache -t antidotelabs/utility:$(TARGET_VERSION) .
 	docker push antidotelabs/utility:$(TARGET_VERSION)


### PR DESCRIPTION
The nightly build is up and running but because Docker uses cached images by default for any unchanged Dockerfile actions, any upstream fixes don't have any impact. For instance @cloudtoad fixed an issue in the [upstream napalm pack](https://github.com/nre-learning/stackstorm-napalm/pull/2) for our stackstorm image which is pulled by this Dockerfile, but since the line in the Dockerfile hasn't changed, it continues to use the cached image without the fix.

Going forward each image's Makefile will ignore the cache and build each image from scratch, to ensure the latest updates in all aspects of the build specification.