### PR TITLE
Update Juniper collection with link to training

### DIFF
--- a/collections/juniper/collection.meta.yaml
+++ b/collections/juniper/collection.meta.yaml
@@ -2,7 +2,7 @@
 id: 1
 title: Juniper Networks
 image: https://raw.githubusercontent.com/nre-learning/nrelabs-curriculum/master/collections/juniper/juniper.png
-website: https://learningportal.juniper.net/juniper/user_activity_info.aspx?id=5357
+website: https://learningportal.juniper.net/juniper/user_activity_info.aspx?id=10275
 contactEmail: "support@juniper.net"
 
 # Why should users view your collection?

--- a/collections/juniper/collection.meta.yaml
+++ b/collections/juniper/collection.meta.yaml
@@ -2,7 +2,7 @@
 id: 1
 title: Juniper Networks
 image: https://raw.githubusercontent.com/nre-learning/nrelabs-curriculum/master/collections/juniper/juniper.png
-website: https://juniper.net
+website: https://learningportal.juniper.net/juniper/user_activity_info.aspx?id=5357
 contactEmail: "support@juniper.net"
 
 # Why should users view your collection?


### PR DESCRIPTION
Rather than link to the main website, it's probably more useful to link directly to training resources where folks can continue their learning journey.

![Screenshot from 2019-09-16 21-51-21](https://user-images.githubusercontent.com/4230395/65012560-9e2a2180-d8cc-11e9-9cfd-d15d24d2cfd7.png)