### PR TITLE
Add wordlist package to Kali image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updated collection in BASH lesson file to 9 (PacketPushers) [#258](https://github.com/nre-learning/nrelabs-curriculum/pull/258)
 - Disable caching for all image builds [#260](https://github.com/nre-learning/nrelabs-curriculum/pull/260)
 - New Images and PoC Lessons for NXTWORK 2019 Hackathon [#261](https://github.com/nre-learning/nrelabs-curriculum/pull/261)
+- Add wordlist package to Kali image [#272](https://github.com/nre-learning/nrelabs-curriculum/pull/272)
 
 ## v1.0.0 - August 08, 2019
 

--- a/images/kali/Dockerfile
+++ b/images/kali/Dockerfile
@@ -1,7 +1,7 @@
 FROM kalilinux/kali-linux-docker
 
 RUN apt-get update && apt-get install -y openssh-server \
-    zlib1g-dev libcurl4-openssl-dev libxml2 libxml2-dev libxslt1-dev ruby-dev build-essential
+    zlib1g-dev libcurl4-openssl-dev libxml2 libxml2-dev libxslt1-dev ruby-dev build-essential wordlists
 
 # python \
 #     python-pip dnsutils iputils-ping git vim curl util-linux sshpass nano jq sudo


### PR DESCRIPTION
The wordlist package is needed by `wpscan` for the lesson we're building to use this image, and the default Kali Docker image doesn't include it.

@94halldah - please review.