### PR TITLE
Set tshoot lesson images to use centos7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Set tshoot lesson images to use centos7 [#275](https://github.com/nre-learning/nrelabs-curriculum/pull/275)
 - Fixed Cumulus PTR demo [#271](https://github.com/nre-learning/nrelabs-curriculum/pull/271)
 - Added Cumulus PTR demo [#253](https://github.com/nre-learning/nrelabs-curriculum/pull/253)
 - Updated collection in BASH lesson file to 9 (PacketPushers) [#258](https://github.com/nre-learning/nrelabs-curriculum/pull/258)

--- a/images/asterisk/Dockerfile
+++ b/images/asterisk/Dockerfile
@@ -4,7 +4,7 @@
 #    Edit the /etc/yum.repos.d/tucny-asterisk.repo and set 'enabled=1' for 'asterisk-common' and the version of asterisk you want to use
 #    Install the packages you want. 'dnf install asterisk' or 'yum install asterisk' can get you started.
 
-FROM centos
+FROM centos:7
 
 RUN yum install -y iproute epel-release lshw openssh-server \
     && yum install -y wget \

--- a/images/netbox/Dockerfile
+++ b/images/netbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 
 RUN yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
 RUN yum install -y epel-release

--- a/images/pjsua-lindsey/Dockerfile
+++ b/images/pjsua-lindsey/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 
 WORKDIR /root
 RUN yum install -y gcc gcc-c++ make epel-release bzip2 iproute openssh-server \


### PR DESCRIPTION
The CentOS base images were updated with the release of CentOS 8, and the images that were built to use this didn't specify tag, and are not compatible with 8 (currently breaking in nightly builds). Setting statically to 7 for now. We can, of course, circle back in the future and fix the incompatibility and use 8 if needed.