### PR TITLE
Temporarily pin netmiko to 2.4.2 in st2 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add wordlist package to Kali image [#272](https://github.com/nre-learning/nrelabs-curriculum/pull/272)
 - Updates to utility image [#285](https://github.com/nre-learning/nrelabs-curriculum/pull/285)
 - Update YAML Loader statements[#292](https://github.com/nre-learning/nrelabs-curriculum/pull/292)
+- Temporarily pin netmiko to 2.4.2 in st2 image [#293](https://github.com/nre-learning/nrelabs-curriculum/pull/293)
 
 ## v1.0.0 - August 08, 2019
 

--- a/images/st2/Dockerfile
+++ b/images/st2/Dockerfile
@@ -70,6 +70,7 @@ RUN screen -d -m /start_st2_services.sh && sleep 15 \
     && st2 run packs.setup_virtualenv packs=examples \ 
     && st2 pack remove napalm && st2 pack install https://github.com/nre-learning/stackstorm-napalm.git
 RUN /opt/stackstorm/virtualenvs/napalm/bin/pip install ncclient==0.6.0
+RUN /opt/stackstorm/virtualenvs/napalm/bin/pip install --upgrade netmiko==2.4.2
 ARG CACHEBUST=0
 
 #####################################################################################################


### PR DESCRIPTION
As discussed in https://github.com/nre-learning/nrelabs-curriculum/issues/280, this PR temporarily downgrades netmiko to 2.4.2 to get things working again quickly enough, since the st2 image doesn't yet support the py3 version required for the latest netmiko.

https://github.com/nre-learning/nrelabs-curriculum/issues/294 will provide a longer-term solution for this by upgrading python and stackstorm, and will be implemented in a future (hopefully the next) release.

Closes #280 