### PR TITLE
Cleaning up Troubleshooting Lesson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - Temporarily pin netmiko to 2.4.2 in st2 image [#293](https://github.com/nre-learning/nrelabs-curriculum/pull/293)
 - Added stage 4 for the "Network Automation with Salt" lesson (configuring junos). [#235](https://github.com/nre-learning/nrelabs-curriculum/pull/235)
 - Resized/moved some collections logos [#296](https://github.com/nre-learning/nrelabs-curriculum/pull/296)
-  
+- Cleaning up Troubleshooting Lesson [#299](https://github.com/nre-learning/nrelabs-curriculum/pull/299)
+
 ## v1.0.0 - August 08, 2019
 
 - Replaced all individual snippet indices with 'this' keyword [#221](https://github.com/nre-learning/nrelabs-curriculum/pull/221)

--- a/lessons/workflows/lesson-21-tshoot-ipphone/lesson.meta.yaml
+++ b/lessons/workflows/lesson-21-tshoot-ipphone/lesson.meta.yaml
@@ -2,7 +2,6 @@
 lessonName: Automating the Troubleshooting Chain
 lessonId: 21
 category: workflows
-lessondiagram: https://raw.githubusercontent.com/nre-learning/nrelabs-curriculum/v0.3.2/lessons/lesson-21/lessondiagram.png
 tier: prod
 
 # TODO(mierdin): add Python when there is a lesson for it
@@ -45,30 +44,20 @@ endpoints:
     port: 22
     type: ssh
 
-- name: vqfx3
-  image: antidotelabs/vqfx-snap3
-  configurationType: napalm-junos
-  presentations:
-  - name: cli
-    port: 22
-    type: ssh
-
 - name: asterisk
   image: antidotelabs/asterisk
   additionalPorts: [8088]
 
-- name: netbox
-  image: antidotelabs/netbox
-  additionalPorts: [8000]
+# For future version of lesson
+#
+# - name: netbox
+#   image: antidotelabs/netbox
+#   additionalPorts: [8000]
 
 
 connections:
 - a: vqfx1
   b: vqfx2
-- a: vqfx2
-  b: vqfx3
-- a: vqfx3
-  b: vqfx1
 - a: vqfx2
   b: sipphone
 - a: vqfx1

--- a/lessons/workflows/lesson-21-tshoot-ipphone/stage1/guide.md
+++ b/lessons/workflows/lesson-21-tshoot-ipphone/stage1/guide.md
@@ -2,26 +2,28 @@
 
 In this lesson, we'll talk about breaking a common workflow down into smaller pieces.  Using the knowledge we gained from previous lessons, we'll build a small script for each piece of the workflow.  Finally, we'll string these small scripts together at the linux command-line in order to rebuild our workflow.
 
-Scenario:
+## Scenario:
 
 An IP phone user has called to report problems with their audio.  They are unable or unwilling to provide any additional information about their phone, besides their extension number.  Our goal over this lesson is to find the name of the access switch and the interface that their phone is attached to.
 
 In this first step, we've created a small script to retrieve the IP address of a phone from an IP PBX, given the extension number of the phone.  
 
+## Start Soft Phone Client
+
 Before we run this script, we'll have to start the SIP phone software located on the 'sipphone' box.  Click the button below to do this.
 
 ```
+cd /antidote
 ./phone.sh
 ```
 <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('sipphone', this)">Run this snippet</button>
 
-...
-
 OK, the phone is now registered to the PBX.  To see this yourself, hit enter in the 'sipphone' tab.  You should see that account 2 has a status of OK/200.  This means the phone is registered to the PBX.
 In this case, the phone has extension 1107 assigned to it.
 
-Now let's get the IP of the phone by querying the SIP PBX.  Click the button below.
+## Querying For The Next Troubleshooting Clue
 
+Now let's get the IP of the phone by querying the SIP PBX.  Click the button below.
 
 ```
 cd /antidote
@@ -29,6 +31,7 @@ cd /antidote
 ```
 <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', this)">Run this snippet</button>
 
-And there it is!  For many enterprise customers, getting the IP address of a software or hardware client such as a phone, a virtual-machine host, a chat client, or a storage element can be difficult and time consuming. Having a script such as this where you can pass in non-network data, such as the extension number, to retrieve network data, such as an IP, can save time and frustration!
+This seems simple, but is already very a very powerful tool. For many enterprise customers, getting the IP address of a software or hardware client such as a phone, a virtual-machine host, a chat client, or a storage element can be difficult and time consuming. Having a script such as this where you can pass in non-network data, such as the extension number, to retrieve network data, such as an IP, can save time and frustration!
 
+In future versions of this lesson, we'll explore the use of this data to link with other pieces of infrastructure data, to build our troubleshooting journey.
 


### PR DESCRIPTION
Making some mostly cosmetic changes to the troubleshooting lesson. For now, we can disable the netbox endpoint, as it's not currently used. I left it in, commented-out. Also, `vqfx3` isn't needed, so we can remove it from the lesson.

The other changes are almost purely aesthetic. I did also add a second `cd` command to ensure that both the `sipphone` and `linux` endpoints start in the right directory before executing their commands.

Closes #263 