### PR TITLE
(git lesson) Remove command "show" from 1st stage summary

### DIFF
--- a/lessons/fundamentals/lesson-17-git/stage1/guide.md
+++ b/lessons/fundamentals/lesson-17-git/stage1/guide.md
@@ -98,4 +98,3 @@ To summarize, the commands we learned in this section were:
 
 - `git init` - initialize a new git repository
 - `git config` - work with Git configuration options, both globally (with the `--global` flag) and locally in the current repository.
-- `git show` - show details about something in Git - in this case, a commit


### PR DESCRIPTION
As spotted by @Mierdin in the first Labs & Latte episode, the show command is useless in that summary
