### PR TITLE
Fix config for stage4 vqfx1 config in ansible lesson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Fix config for stage4 vqfx1 config in ansible lesson [#313](https://github.com/nre-learning/nrelabs-curriculum/pull/313)
 
 ## v1.1.0 - February 01, 2020
 

--- a/lessons/tools/lesson-41-ansible-network/stage4/configs/vqfx1.txt
+++ b/lessons/tools/lesson-41-ansible-network/stage4/configs/vqfx1.txt
@@ -102,7 +102,7 @@
                     <family>
                         <inet>
                             <address>
-                                <name>10.12.0.11/24</name>
+                                <name>10.10.10.1/30</name>
                             </address>
                         </inet>
                     </family>
@@ -115,7 +115,7 @@
                     <family>
                         <inet>
                             <address>
-                                <name>10.10.10.1/30</name>
+                                <name>10.31.0.11/24</name>
                             </address>
                         </inet>
                     </family>


### PR DESCRIPTION
In response to a report raised in https://discuss.nrelabs.io/t/ospf-lab-stage-4-on-ansible/244/2

/cc @IPvSean - looks like the updated IP address was just placed on the wrong interface. Easy to fix.