### PR TITLE
added gnmic endpoint image

### DIFF
--- a/images/gnmic/Dockerfile
+++ b/images/gnmic/Dockerfile
@@ -1,0 +1,4 @@
+FROM gnmic/gnmic as source
+
+FROM antidotelabs/utility
+COPY --from=source /app/gnmic /usr/bin

--- a/images/gnmic/Makefile
+++ b/images/gnmic/Makefile
@@ -1,0 +1,9 @@
+# SHELL=/bin/bash
+
+TARGET_VERSION ?= latest
+
+all: docker
+
+docker:
+	docker build --pull --no-cache -t antidotelabs/gnmic:$(TARGET_VERSION) .
+	docker push antidotelabs/gnmic:$(TARGET_VERSION)

--- a/images/gnmic/image.meta.yaml
+++ b/images/gnmic/image.meta.yaml
@@ -1,0 +1,9 @@
+slug: gnmic
+description: gnmic is a gNMI CLI client
+flavor: untrusted
+sshUser: antidote
+sshPassword: antidotepassword
+configUser: antidote
+configPassword: antidotepassword
+networkInterfaces:
+  - "eth0"


### PR DESCRIPTION
This image is a first step in adding `gnmic` lesson to nre.labs as per #339 

It adds the relevant endpoint images based off of `antidote/utility` image.