### PR TITLE
Fix connectivity issues in Ansible lesson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Fix connectivity issues in Ansible lesson [#349](https://github.com/nre-learning/nrelabs-curriculum/pull/349)
 - Revert tshoot lesson back to vQFX [#347](https://github.com/nre-learning/nrelabs-curriculum/pull/347)
 - Fix troubleshooting lesson scripts to be py3 compatible [#345](https://github.com/nre-learning/nrelabs-curriculum/pull/345)
 - Migrating from travis to github actions [#344](https://github.com/nre-learning/nrelabs-curriculum/pull/344)

--- a/lessons/ansible-network-automation/stage0/hosts
+++ b/lessons/ansible-network-automation/stage0/hosts
@@ -1,6 +1,6 @@
 [all:vars]
 ansible_user=antidote
-ansible_ssh_pass=antidotepassword
+ansible_password=antidotepassword
 
 [cumulus]
 cvx1

--- a/lessons/ansible-network-automation/stage3/ansible.cfg
+++ b/lessons/ansible-network-automation/stage3/ansible.cfg
@@ -8,3 +8,8 @@ deprecation_warnings = False
 host_key_checking = False
 retry_files_enabled = False
 inventory = /antidote/stage0/hosts
+
+# https://github.com/ansible-semaphore/semaphore/issues/309
+[ssh_connection]
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
+control_path = /dev/shm/cp%%h-%%p-%%r

--- a/lessons/ansible-network-automation/stage3/configs/vqfx1-junos.txt
+++ b/lessons/ansible-network-automation/stage3/configs/vqfx1-junos.txt
@@ -81,7 +81,33 @@
                 </providers>
             </extensions>
         </system>
-        <interfaces operation="merge">
+        <interfaces operation="replace">
+            <interface>
+                <name>em0</name>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <inet>
+                            <address>
+                                <name>10.0.0.15/24</name>
+                            </address>
+                        </inet>
+                    </family>
+                </unit>
+            </interface>
+            <interface>
+                <name>em1</name>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <inet>
+                            <address>
+                                <name>169.254.0.2/24</name>
+                            </address>
+                        </inet>
+                    </family>
+                </unit>
+            </interface>
             <interface>
                 <name>em3</name>
                 <unit>


### PR DESCRIPTION
This fixes some long-standing issues in the Ansible lesson.

/cc @IPvSean 

# Banner SSH Timeout connecting to vQFX

This has been a [known problem for some time](https://github.com/nre-learning/nrelabs-curriculum/issues/304). At the time the only known solution was coming in this PR: https://github.com/ansible/ansible/pull/68184

However, as of today it's still not merged, and unclear if it would actually fix the problem. On a whim I did some additional googling and found [this SO post](https://stackoverflow.com/questions/49629480/ansible-fails-to-connect-with-ssh-banner-exchange), which mentions this could be caused by using the wrong ansible credential parameters. I changed this and it **immediately** and consistently fixed the problem. So this PR includes that fix.

Closes https://github.com/nre-learning/nrelabs-curriculum/issues/304

# Cumulus Connection Issue

Also started running into this:

```
TASK [template out cumulus configuration for free range routing] ************************************************************************
fatal: [cvx1]: UNREACHABLE! => changed=false 
  msg: |-
    Failed to connect to the host via ssh: Warning: Permanently added 'cvx1,10.101.158.199' (ECDSA) to the list of known hosts.
    Control socket connect(/home/antidote/.ansible/cp/10b222d3e0): Connection refused
    Failed to connect to new control master
  unreachable: true
```

[This issue](https://github.com/ansible-semaphore/semaphore/issues/309) suggested some additional configuration options to ansible.cfg, which I added in the final stage. Other stages which include cumulus may want to borrow this section.
