### PR TITLE
Updated images to not include networkInterfaces field by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,8 @@ env:
   emptyArray: "[]"
   emptyLiteral: "empty"
   retagSource: "v1.3.0"
-  antidoteVersion: "v0.6.2"
+  # TODO - temporary, please update after next platform release
+  antidoteVersion: "v0.7.0-networkinterfaces-test"
 
 jobs:
   prebuild:

--- a/images/ansible/image.meta.yaml
+++ b/images/ansible/image.meta.yaml
@@ -5,7 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-
-

--- a/images/asterisk/image.meta.yaml
+++ b/images/asterisk/image.meta.yaml
@@ -5,7 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-
-

--- a/images/crpd/image.meta.yaml
+++ b/images/crpd/image.meta.yaml
@@ -6,9 +6,3 @@ sshUser: root
 sshPassword: antidotepassword
 configUser: root
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-  - 'eth1'
-  - 'eth2'
-  - 'eth3'
-  - 'eth4'

--- a/images/cvx/image.meta.yaml
+++ b/images/cvx/image.meta.yaml
@@ -5,9 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-  - 'eth1'
-  - 'eth2'
-  - 'eth3'
-

--- a/images/gitea/image.meta.yaml
+++ b/images/gitea/image.meta.yaml
@@ -5,5 +5,3 @@ configUser: root
 configPassword: antidotepassword
 sshUser: "foo"
 sshPassword: "bar"
-networkInterfaces:
-  - 'eth0'

--- a/images/gnmic/image.meta.yaml
+++ b/images/gnmic/image.meta.yaml
@@ -5,5 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - "eth0"

--- a/images/pjsua-lindsey/image.meta.yaml
+++ b/images/pjsua-lindsey/image.meta.yaml
@@ -5,6 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-

--- a/images/salt/image.meta.yaml
+++ b/images/salt/image.meta.yaml
@@ -5,6 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-

--- a/images/stackstorm/image.meta.yaml
+++ b/images/stackstorm/image.meta.yaml
@@ -5,6 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-

--- a/images/terraform/image.meta.yaml
+++ b/images/terraform/image.meta.yaml
@@ -5,6 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-

--- a/images/utility/image.meta.yaml
+++ b/images/utility/image.meta.yaml
@@ -5,8 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'eth0'
-  - 'eth1'
-  - 'eth2'
-  - 'eth3'

--- a/images/vqfx-snap1/image.meta.yaml
+++ b/images/vqfx-snap1/image.meta.yaml
@@ -5,9 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'em0'
-  - 'em3'
-  - 'em4'
-  - 'em5'
-  - 'em6'

--- a/images/vqfx-snap2/image.meta.yaml
+++ b/images/vqfx-snap2/image.meta.yaml
@@ -5,9 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'em0'
-  - 'em3'
-  - 'em4'
-  - 'em5'
-  - 'em6'

--- a/images/vqfx-snap3/image.meta.yaml
+++ b/images/vqfx-snap3/image.meta.yaml
@@ -5,9 +5,3 @@ sshUser: antidote
 sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
-networkInterfaces:
-  - 'em0'
-  - 'em3'
-  - 'em4'
-  - 'em5'
-  - 'em6'


### PR DESCRIPTION
This is an update to bring the curriculum into compatibility with the changes in https://github.com/nre-learning/antidote-core/pull/214

The `networkInterfaces` field is now optional, and not necessary for any of the existing images to include.